### PR TITLE
Bugfix/99 reactive data

### DIFF
--- a/.changeset/neat-doodles-listen.md
+++ b/.changeset/neat-doodles-listen.md
@@ -1,0 +1,5 @@
+---
+"@jfdevelops/react-multi-step-form": patch
+---
+
+Makes step data reactive in `createComponent` function

--- a/packages/core/src/internals/step-schema.ts
+++ b/packages/core/src/internals/step-schema.ts
@@ -605,11 +605,8 @@ export class MultiStepFormStepSchemaInternal<
     chosenSteps extends HelperFnChosenSteps<resolvedStep, stepNumbers>
   >(chosenSteps: chosenSteps) {
     if (HelperFnChosenSteps.isAll(chosenSteps)) {
-      const stepSpecificUpdateFn = typedObjectKeys<
-        resolvedStep,
-        ValidStepKey<stepNumbers>
-      >(this.value).reduce((acc, key) => {
-        acc[key] = this.createStepUpdaterFn(key);
+      const stepSpecificUpdateFn = typedObjectKeys(this.value).reduce((acc, key) => {
+        (acc as any)[key] = this.createStepUpdaterFn(key as never);
 
         return acc;
       }, {} as helperFnUpdateFn<resolvedStep, stepNumbers, ValidStepKey<stepNumbers>>);
@@ -625,7 +622,7 @@ export class MultiStepFormStepSchemaInternal<
 
     if (HelperFnChosenSteps.isTuple<stepNumbers>(chosenSteps, validKeys)) {
       const stepSpecificUpdateFn = chosenSteps.reduce((acc, step) => {
-        acc[step] = this.createStepUpdaterFn(step);
+        (acc as any)[step] = this.createStepUpdaterFn(step);
 
         return acc;
       }, {} as helperFnUpdateFn<resolvedStep, stepNumbers, ValidStepKey<stepNumbers>>);
@@ -642,7 +639,7 @@ export class MultiStepFormStepSchemaInternal<
         HelperFnChosenSteps.objectNotation<`step${stepNumbers}`>,
         ValidStepKey<stepNumbers>
       >(chosenSteps).reduce((acc, key) => {
-        acc[key] = this.createStepUpdaterFn(key);
+        (acc as any)[key] = this.createStepUpdaterFn(key);
 
         return acc;
       }, {} as helperFnUpdateFn<resolvedStep, stepNumbers, ValidStepKey<stepNumbers>>);
@@ -665,7 +662,7 @@ export class MultiStepFormStepSchemaInternal<
         resolvedStep,
         ValidStepKey<stepNumbers>
       >(this.value).reduce((acc, key) => {
-        acc[key] = this.createStepResetterFn(key);
+        (acc as any)[key] = this.createStepResetterFn(key);
 
         return acc;
       }, {} as helperFnResetFn<resolvedStep, stepNumbers, ValidStepKey<stepNumbers>>);
@@ -681,7 +678,7 @@ export class MultiStepFormStepSchemaInternal<
 
     if (HelperFnChosenSteps.isTuple<stepNumbers>(chosenSteps, validKeys)) {
       const stepSpecificUpdateFn = chosenSteps.reduce((acc, step) => {
-        acc[step] = this.createStepResetterFn(step);
+        (acc as any)[step] = this.createStepResetterFn(step);
 
         return acc;
       }, {} as helperFnResetFn<resolvedStep, stepNumbers, ValidStepKey<stepNumbers>>);
@@ -698,7 +695,7 @@ export class MultiStepFormStepSchemaInternal<
         HelperFnChosenSteps.objectNotation<`step${stepNumbers}`>,
         ValidStepKey<stepNumbers>
       >(chosenSteps).reduce((acc, key) => {
-        acc[key] = this.createStepResetterFn(key);
+        (acc as any)[key] = this.createStepResetterFn(key);
 
         return acc;
       }, {} as helperFnResetFn<resolvedStep, stepNumbers, ValidStepKey<stepNumbers>>);

--- a/packages/react/src/field.tsx
+++ b/packages/react/src/field.tsx
@@ -5,6 +5,7 @@ import type {
   Updater,
 } from '@jfdevelops/multi-step-form-core';
 import type { ReactNode } from 'react';
+import { memo, useSyncExternalStore } from 'react';
 
 export namespace field {
   type sharedProps<TField extends string> = {
@@ -59,6 +60,8 @@ export namespace field {
   /**
    * Create a field.
    * @param propsCreator
+   * @param subscribe - Optional subscription function for reactivity
+   * @param getValue - Optional function to get the current field value reactively
    * @returns
    */
   export function create<
@@ -67,14 +70,45 @@ export namespace field {
   >(
     propsCreator: <TField extends fields.getDeep<TResolvedStep, TTargetStep>>(
       name: TField
-    ) => field.childrenProps<TResolvedStep, TTargetStep, TField>
+    ) => field.childrenProps<TResolvedStep, TTargetStep, TField>,
+    subscribe?: (listener: () => void) => () => void,
+    getValue?: <TField extends fields.getDeep<TResolvedStep, TTargetStep>>(
+      name: TField
+    ) => fields.resolveDeepPath<TResolvedStep, TTargetStep, TField>
   ) {
-    const Field: field.component<TResolvedStep, TTargetStep> = (props) => {
-      const { children, name } = props;
-      const createdProps = propsCreator(name);
+    const Field: field.component<TResolvedStep, TTargetStep> = memo(
+      (props) => {
+        const { children, name } = props;
 
-      return children(createdProps);
-    };
+        // Always call the hook, but use no-op functions if subscribe/getValue aren't provided
+        const subscribeFn = subscribe || (() => () => {});
+        const getValueFn = getValue || (() => undefined);
+
+        // Subscribe to changes to trigger rerenders
+        const currentValue = useSyncExternalStore(
+          subscribeFn,
+          () => getValueFn(name),
+          () => getValueFn(name)
+        );
+
+        let createdProps = propsCreator(name);
+
+        // If getValue is provided, override defaultValue with the reactive value
+        if (getValue) {
+          createdProps = {
+            ...createdProps,
+            defaultValue: currentValue,
+          } as typeof createdProps;
+        }
+
+        return children(createdProps);
+      },
+      // Custom comparison: only compare the `name` prop
+      // The `children` function will always be a new reference, but that's okay
+      // because we only re-render when the field value changes (via useSyncExternalStore)
+      // or when the `name` prop changes
+      (prevProps, nextProps) => prevProps.name === nextProps.name
+    );
 
     return Field;
   }

--- a/packages/react/src/hooks/use-selector.ts
+++ b/packages/react/src/hooks/use-selector.ts
@@ -1,0 +1,47 @@
+import type {
+  AnyResolvedStep,
+  StepNumbers,
+  HelperFnChosenSteps,
+  Expand,
+  HelperFnCtx,
+} from '@jfdevelops/multi-step-form-core';
+import { useSyncExternalStore } from 'react';
+
+export type UseSelector<
+  TResolvedStep extends AnyResolvedStep,
+  TSteps extends StepNumbers<TResolvedStep>,
+  TChosenSteps extends HelperFnChosenSteps<TResolvedStep, TSteps>
+> = ReturnType<typeof createUseSelector<TResolvedStep, TSteps, TChosenSteps>>;
+export type SelectorFn<
+  TResolvedStep extends AnyResolvedStep,
+  TSteps extends StepNumbers<TResolvedStep>,
+  TChosenSteps extends HelperFnChosenSteps<TResolvedStep, TSteps>,
+  TSelected
+> = (
+  ctx: Expand<HelperFnCtx<TResolvedStep, TSteps, TChosenSteps>>
+) => TSelected;
+
+export function createUseSelector<
+  TResolvedStep extends AnyResolvedStep,
+  TSteps extends StepNumbers<TResolvedStep>,
+  TChosenSteps extends HelperFnChosenSteps<TResolvedStep, TSteps>
+>(
+  createCtx: () => Expand<HelperFnCtx<TResolvedStep, TSteps, TChosenSteps>>,
+  subscribe: (listener: () => void) => () => void
+) {
+  return <selected>(
+    selector: SelectorFn<TResolvedStep, TSteps, TChosenSteps, selected>
+  ) => {
+    return useSyncExternalStore(
+      subscribe,
+      () => {
+        const currentCtx = createCtx();
+        return selector(currentCtx);
+      },
+      () => {
+        const currentCtx = createCtx();
+        return selector(currentCtx);
+      }
+    );
+  };
+}

--- a/packages/react/src/selector.tsx
+++ b/packages/react/src/selector.tsx
@@ -1,0 +1,72 @@
+import {
+  AnyResolvedStep,
+  StepNumbers,
+  HelperFnChosenSteps,
+  Expand,
+  HelperFnCtx,
+} from '@jfdevelops/multi-step-form-core';
+import { createUseSelector, SelectorFn } from './hooks/use-selector';
+import { Fragment } from 'react/jsx-runtime';
+import { createElement, memo } from 'react';
+
+export namespace selector {
+  export type props<
+    TResolvedStep extends AnyResolvedStep,
+    TSteps extends StepNumbers<TResolvedStep>,
+    TChosenSteps extends HelperFnChosenSteps<TResolvedStep, TSteps>,
+    TSelected
+  > = {
+    selector: SelectorFn<TResolvedStep, TSteps, TChosenSteps, TSelected>;
+    children?: (selected: TSelected) => React.ReactNode;
+  };
+  export type component<
+    TResolvedStep extends AnyResolvedStep,
+    TSteps extends StepNumbers<TResolvedStep>,
+    TChosenSteps extends HelperFnChosenSteps<TResolvedStep, TSteps>
+  > =
+    /**
+     * A component for reactively displaying a value from the form context.
+     * Unlike `useSelector`, this component only re-renders itself, not the parent component.
+     * Use this when you want to display a reactive value without causing parent re-renders.
+     *
+     * @param selector - A function that receives the current step's context and returns the selected value
+     * @param children - Optional render prop that receives the selected value
+     *
+     * @example
+     * <Selector selector={(ctx) => ctx.step1.fields.firstName.defaultValue}>
+     *   {(value) => <p>First name: {value}</p>}
+     * </Selector>
+     */
+    <TSelected>(
+      props: props<TResolvedStep, TSteps, TChosenSteps, TSelected>
+    ) => React.ReactNode;
+
+  export function create<
+    TResolvedStep extends AnyResolvedStep,
+    TSteps extends StepNumbers<TResolvedStep>,
+    TChosenSteps extends HelperFnChosenSteps<TResolvedStep, TSteps>
+  >(
+    createCtx: () => Expand<HelperFnCtx<TResolvedStep, TSteps, TChosenSteps>>,
+    subscribe: (listener: () => void) => () => void
+  ) {
+    const useSelector = createUseSelector(createCtx, subscribe);
+    const Selector: component<TResolvedStep, TSteps, TChosenSteps> = ({
+      selector,
+      children,
+    }) => {
+      const selected = useSelector(selector);
+
+      if (children) {
+        return createElement(Fragment, null, children(selected));
+      }
+      return createElement(Fragment, null, String(selected ?? ''));
+    };
+
+    return memo(
+      Selector,
+      // Always return false to allow re-renders when the selected value changes
+      // The memoization is just to prevent re-renders when parent re-renders
+      () => false
+    );
+  }
+}

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -28,10 +28,12 @@ import {
   type ValidStepKey,
 } from '@jfdevelops/multi-step-form-core';
 import { MultiStepFormStepSchemaInternal } from '@jfdevelops/multi-step-form-core/_internals';
-import type { ComponentPropsWithRef, ReactNode } from 'react';
+import React, { memo, type ComponentPropsWithRef, type ReactNode } from 'react';
 import { field } from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
-import { resolvedCtxCreator } from './utils';
+import { createUseSelector, type UseSelector } from './hooks/use-selector';
+import { getValidatedCustomInputHooks, resolvedCtxCreator } from './utils';
+import { selector } from './selector';
 
 export interface MultiStepFormSchemaStepConfig<
   TStep extends Step<TCasing>,
@@ -203,6 +205,32 @@ export namespace StepSpecificComponent {
           >
         >
       >;
+      /**
+       * A hook for reactively selecting a value from the form context.
+       * The selector function receives the contextual data for the currently rendered step, and returns any derived value.
+       * `useSelector` will automatically provide the latest context data on updates, and will subscribe the caller for automatic re-renders when the underlying data changes.
+       *
+       * @param selector - A function that receives the current step's context and returns the selected value
+       * @returns The derived value, which will re-render the component on change
+       *
+       * @example
+       * const someValue = useSelector(ctx => ctx.fields.username.value);
+       */
+      useSelector: UseSelector<TResolvedStep, TSteps, TChosenSteps>;
+      /**
+       * A component for reactively displaying a value from the form context.
+       * Unlike `useSelector`, this component only re-renders itself, not the parent component.
+       * Use this when you want to display a reactive value without causing parent re-renders.
+       *
+       * @param selector - A function that receives the current step's context and returns the selected value
+       * @param children - Optional render prop that receives the selected value
+       *
+       * @example
+       * <Selector selector={(ctx) => ctx.step1.fields.firstName.defaultValue}>
+       *   {(value) => <p>First name: {value}</p>}
+       * </Selector>
+       */
+      Selector: selector.component<TResolvedStep, TSteps, TChosenSteps>;
     };
 
   export type callback<
@@ -302,7 +330,7 @@ export namespace StepSpecificComponent {
     debug?: boolean;
     useFormInstance?: formInstanceOptions<
       TFormInstanceAlias,
-      HelperFnInputBase<TResolvedStep, TSteps, TTargetStep> & {
+      Pick<HelperFnInputBase<TResolvedStep, TSteps, TTargetStep>, 'ctx'> & {
         /**
          * An object containing all the default values for the current step.
          */
@@ -580,22 +608,13 @@ export class MultiStepFormStepSchema<
         ValidStepKey<stepNumbers>
       >;
       const id = form?.id ?? key;
-      const ctx = createCtx<
-        resolvedStep,
-        stepNumbers,
-        HelperFnChosenSteps.tupleNotation<ValidStepKey<stepNumbers>>
-      >(this.value, stepData);
 
       return {
-        createComponent: this.createStepSpecificComponentFactory(
-          stepData,
-          {
-            isStepSpecific: true,
-            defaultId: id,
-            form: form as never,
-          },
-          ctx
-        ),
+        createComponent: this.createStepSpecificComponentFactory(stepData, {
+          isStepSpecific: true,
+          defaultId: id,
+          form: form as never,
+        }),
       };
     });
   }
@@ -622,8 +641,48 @@ export class MultiStepFormStepSchema<
     return (props: formProps) => render(ctx, props);
   }
 
+  private createResolvedCtx<
+    chosenStep extends HelperFnChosenSteps.tupleNotation<
+      ValidStepKey<stepNumbers>
+    >,
+    additionalCtx
+  >(
+    options: {
+      stepData: chosenStep;
+      logger: MultiStepFormLogger;
+    } & StepSpecificComponent.CtxSelector<
+      resolvedStep,
+      stepNumbers,
+      chosenStep,
+      additionalCtx
+    >
+  ) {
+    const { logger, stepData, ctxData } = options;
+    // Create ctx fresh each time to ensure it has the latest this.value
+    const ctx = createCtx<resolvedStep, stepNumbers, chosenStep>(
+      this.value,
+      stepData
+    );
+    let resolvedCtx = ctx as Expand<
+      HelperFnCtx<resolvedStep, stepNumbers, chosenStep>
+    >;
+
+    if (ctxData) {
+      const [targetStep] = stepData;
+      const { [targetStep]: _, ...values } = this.value;
+      const createResolvedCtx = resolvedCtxCreator(logger, values);
+
+      resolvedCtx = createResolvedCtx({ ctx: resolvedCtx, ctxData });
+    }
+
+    return resolvedCtx;
+  }
+
   private createStepSpecificComponentImpl<
-    chosenStep extends HelperFnChosenSteps<resolvedStep, stepNumbers>
+    chosenStep extends HelperFnChosenSteps.tupleNotation<
+      ValidStepKey<stepNumbers>
+    >,
+    additionalCtx = {}
   >(
     stepData: chosenStep,
     config: CreateComponentImplConfig.stepSpecificConfig<
@@ -632,52 +691,33 @@ export class MultiStepFormStepSchema<
       formEnabledFor,
       formProps
     >,
-    input: HelperFnInputBase<resolvedStep, stepNumbers, chosenStep>,
-    extraInput = {}
+    extraConfig?: {
+      logger?: MultiStepFormLogger;
+      input?: (
+        ctx: Expand<HelperFnCtx<resolvedStep, stepNumbers, chosenStep>>
+      ) => Record<string, unknown>;
+    } & StepSpecificComponent.CtxSelector<
+      resolvedStep,
+      stepNumbers,
+      chosenStep,
+      additionalCtx
+    >
   ) {
     return <props>(fn: Function) =>
       ((props: props) => {
+        const ctxData = extraConfig?.ctxData;
+        const logger = extraConfig?.logger ?? new MultiStepFormLogger();
+        const resolvedCtx = this.createResolvedCtx({
+          stepData,
+          ctxData,
+          logger,
+        });
+        const extraInput = extraConfig?.input?.(resolvedCtx) ?? {};
         // Call hook functions from extraInput at the top level of the component
         // This ensures hooks are called in a valid React context (before any conditionals)
-        const hookResults: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(extraInput)) {
-          if (typeof value === 'function') {
-            try {
-              const result = value();
-              // Verify the hook was actually called and returned a value
-              // (hooks should always return something, even if it's undefined)
-              hookResults[key] = result;
-
-              // In development, we can add additional verification here
-              // Log hook calls for debugging (can be disabled in production by removing console.debug)
-              // if (typeof console !== 'undefined' && console.debug) {
-              //   console.debug(
-              //     `[multi-step-form] Hook "${key}" called successfully`,
-              //     { result: result === undefined ? 'defined' : 'undefined' }
-              //   );
-              // }
-            } catch (error) {
-              // Provide helpful error message if hook throws
-              const errorMessage =
-                error instanceof Error ? error.message : String(error);
-
-              throw new Error(
-                `[multi-step-form] Error calling hook "${key}" in useFormInstance.render: ${errorMessage}\n\n` +
-                  `This usually means:\n` +
-                  `1. The hook is being called outside of a React component\n` +
-                  `2. The hook has invalid dependencies or configuration\n` +
-                  `3. There's an error in your hook implementation\n\n` +
-                  `Original error: ${errorMessage}`,
-                { cause: error }
-              );
-            }
-          } else {
-            hookResults[key] = value;
-          }
-        }
+        const hookResults = getValidatedCustomInputHooks(extraInput);
 
         const { defaultId, form } = config;
-        const { ctx } = input;
 
         // Safe cast here since the step specific `createComponent` will always have
         // `stepData` as a tuple
@@ -708,85 +748,112 @@ export class MultiStepFormStepSchema<
           typeof current.fields === 'object',
           `[${step}:createComponent]: the "fields" property must be an object, was ${typeof current.fields}`
         );
-        const stepUpdater = this.#internal.createStepUpdaterFn(step);
 
+        // Memoize Field component to prevent remounting on every render
+        // This ensures input focus is maintained when ctx changes
         const Field = field.create<
           resolvedStep,
           HelperFnChosenSteps.resolve<resolvedStep, stepNumbers, chosenStep>
-        >((name) => {
-          const currentFields = Object.keys(
-            current.fields as Record<string, unknown>
-          );
+        >(
+          (name) => {
+            // Access current step data directly to avoid stale closure
+            const currentStep = this.value[
+              step as keyof resolvedStep
+            ] as typeof current;
+            const currentFields = Object.keys(
+              currentStep.fields as Record<string, unknown>
+            );
 
-          invariant(
-            typeof name === 'string',
-            (formatter) =>
-              `[${step}:Field]: the "name" prop must be a string and a valid field for ${step}. Available fields include: "${formatter.format(
-                currentFields
-              )}"`
-          );
-          // TODO add support for deep keys (`name`)
+            invariant(
+              typeof name === 'string',
+              (formatter) =>
+                `[${step}:Field]: the "name" prop must be a string and a valid field for ${step}. Available fields include: "${formatter.format(
+                  currentFields
+                )}"`
+            );
+            // TODO add support for deep keys (`name`)
 
-          invariant(
-            name in (current.fields as object),
-            (formatter) =>
-              `[${step}:Field]: the field "${name}" doesn't exist for the current step. Available fields include: "${formatter.format(
-                currentFields
-              )}".`
-          );
+            invariant(
+              name in (currentStep.fields as object),
+              (formatter) =>
+                `[${step}:Field]: the field "${name}" doesn't exist for the current step. Available fields include: "${formatter.format(
+                  currentFields
+                )}".`
+            );
 
-          invariant(
-            'update' in current,
-            `[${step}:Field]: No "update" function was found`
-          );
+            invariant(
+              'update' in currentStep,
+              `[${step}:Field]: No "update" function was found`
+            );
 
-          const defaultValue = this.getValue(step as never, name as never);
+            const defaultValue = this.getValue(step as never, name as never);
 
-          const { label, nameTransformCasing, type } = (
-            current.fields as AnyStepField
-          )[name];
-          const targetFields = `fields.${name}.defaultValue`;
+            const { label, nameTransformCasing, type } = (
+              currentStep.fields as AnyStepField
+            )[name];
+            const targetFields = `fields.${name}.defaultValue`;
 
-          return {
-            defaultValue,
-            label,
-            nameTransformCasing,
-            type,
-            name,
-            onInputChange: (value: unknown) => {
-              // Handle Updater pattern: if value is a function, call it with the current field value
-              let resolvedValue;
+            return {
+              defaultValue,
+              label,
+              nameTransformCasing,
+              type,
+              name,
+              onInputChange: (value: unknown) => {
+                // Handle Updater pattern: if value is a function, call it with the current field value
+                let resolvedValue;
 
-              if (typeof value === 'function') {
-                const defaultValue = this.getValue(
-                  step as never,
-                  name as never
-                );
+                if (typeof value === 'function') {
+                  const defaultValue = this.getValue(
+                    step as never,
+                    name as never
+                  );
 
-                resolvedValue = value(defaultValue);
-              } else {
-                resolvedValue = value;
-              }
+                  resolvedValue = value(defaultValue);
+                } else {
+                  resolvedValue = value;
+                }
 
-              this.update({
-                targetStep: step,
-                updater: resolvedValue as never,
-                fields: [targetFields] as never,
-              });
-            },
-            reset: () =>
-              this.reset({
-                fields: [targetFields] as never,
-                targetStep: step,
-              }),
-          } as never;
-        });
+                this.update({
+                  targetStep: step,
+                  updater: resolvedValue as never,
+                  fields: [targetFields] as never,
+                });
+              },
+              reset: () =>
+                this.reset({
+                  fields: [targetFields] as never,
+                  targetStep: step,
+                }),
+            } as never;
+          },
+          this.subscribe,
+          (name) => this.getValue(step as never, name as never)
+        );
+
+        // Create useSelector hook for reactive value access via selector
+        // This allows getting values from ctx reactively without causing re-renders
+        // Pass a function that creates fresh ctx on each call to avoid stale closures
+        const useSelector = createUseSelector(
+          () => this.createResolvedCtx({ stepData, ctxData, logger }),
+          this.subscribe
+        );
+
+        // Create Selector component that uses useSelector internally
+        // This allows parts of the UI to subscribe to specific values without
+        // causing the parent component to re-render
+        const Selector = selector.create(
+          () => this.createResolvedCtx({ stepData, ctxData, logger }),
+          this.subscribe
+        );
 
         let fnInput = {
-          ctx,
-          onInputChange: stepUpdater,
+          ctx: resolvedCtx,
+          onInputChange: this.#internal.createStepUpdaterFn(step),
           reset: this.#internal.createStepResetterFn(step),
           Field,
+          useSelector,
+          Selector,
           ...hookResults,
         };
 
@@ -834,8 +901,8 @@ export class MultiStepFormStepSchema<
       formAlias,
       formEnabledFor,
       formProps
-    >,
-    ctx: HelperFnCtx<resolvedStep, stepNumbers, chosenStep>
+    >
+    // ctx: HelperFnCtx<resolvedStep, stepNumbers, chosenStep>
   ): StepSpecificCreateComponentFn<
     resolvedStep,
     stepNumbers,
@@ -847,17 +914,7 @@ export class MultiStepFormStepSchema<
     const createStepSpecificComponentImpl =
       this.createStepSpecificComponentImpl.bind(this);
     const createDefaultValues = this.createDefaultValues.bind(this);
-
-    // Not exactly sure why `this.value` could be undefined, but it can be so
-    // we fallback to the internal value
-    const resolvedValues = this.value;
     const [targetStep] = stepData;
-    const update = this.#internal
-      .createStepUpdaterFn(targetStep)
-      .bind(this.#internal) as never;
-    const reset = this.#internal
-      .createStepResetterFn(targetStep)
-      .bind(this.#internal) as never;
 
     function impl<props = undefined>(
       fn: CreateStepSpecificComponentCallback<
@@ -930,23 +987,13 @@ export class MultiStepFormStepSchema<
         { [_ in formInstanceAlias]: formInstance }
       >
     ) {
-      function createResolvedCtx(additionalCtx: unknown) {
-        return (
-          additionalCtx ? { ctx: { ...ctx, ...additionalCtx } } : { ctx }
-        ) as HelperFnInputBase<resolvedStep, stepNumbers, chosenStep>;
-      }
-
       function createStepSpecificComponent() {
         invariant(
           typeof optionsOrFn === 'function',
           'The first argument must be a function'
         );
 
-        return createStepSpecificComponentImpl(
-          stepData,
-          config,
-          createResolvedCtx(undefined)
-        )(optionsOrFn);
+        return createStepSpecificComponentImpl(stepData, config)(optionsOrFn);
       }
 
       if (typeof optionsOrFn === 'object') {
@@ -960,13 +1007,10 @@ export class MultiStepFormStepSchema<
 
         logger.info('First argument is an object');
 
-        const { [targetStep]: _, ...values } = resolvedValues;
-
         invariant(
           typeof fn === 'function',
           'The second argument must be a function'
         );
-        const createdCtx = resolvedCtxCreator(logger, values);
 
         if (useFormInstance) {
           const {
@@ -979,33 +1023,27 @@ export class MultiStepFormStepSchema<
           const [step] =
             stepData as HelperFnChosenSteps.tupleNotation<`step${stepNumbers}`>;
 
-          // Store the render function and inputs to call it at component level
-          // This ensures hooks are called in a valid React context
-          const defaultValues = createDefaultValues(step) as never;
-          const resolvedCtx = ctxData ? createdCtx({ ctx, ctxData }) : ctx;
-          const renderInput = { ctx: resolvedCtx, defaultValues };
+          return createStepSpecificComponentImpl(stepData, config, {
+            logger,
+            ctxData,
+            input: (ctx) => {
+              const defaultValues = createDefaultValues(step) as never;
 
-          return createStepSpecificComponentImpl(
-            stepData,
-            config,
-            {
-              ctx: resolvedCtx as never,
-              update,
-              reset,
+              return {
+                [alias]: () =>
+                  render({
+                    ctx,
+                    defaultValues,
+                  }),
+              };
             },
-            {
-              [alias]: () => render(renderInput as never),
-            }
-          )(fn);
+          })(fn);
         }
 
         if (ctxData) {
-          const resolvedCtx = createdCtx({ ctx, ctxData });
-
           return createStepSpecificComponentImpl(stepData, config, {
-            ctx: resolvedCtx as never,
-            update,
-            reset,
+            logger,
+            ctxData,
           })(fn);
         }
 

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,5 +1,6 @@
 import {
   invariant,
+  type Expand,
   type HelperFnChosenSteps,
   type HelperFnCtx,
   type MultiStepFormLogger,
@@ -28,7 +29,7 @@ export function resolvedCtxCreator<
         chosenStep,
         additionalCtx
       >
-    > & { ctx: HelperFnCtx<resolvedStep, stepNumbers, chosenStep> }
+    > & { ctx: Expand<HelperFnCtx<resolvedStep, stepNumbers, chosenStep>> }
   ) {
     const { ctx, ctxData } = options;
 
@@ -53,4 +54,46 @@ export function resolvedCtxCreator<
 
     return resolvedCtx;
   };
+}
+
+export function getValidatedCustomInputHooks(input: Record<string, unknown>) {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === 'function') {
+      try {
+        const result = value();
+        // Verify the hook was actually called and returned a value
+        // (hooks should always return something, even if it's undefined)
+        result[key] = result;
+
+        // In development, we can add additional verification here
+        // Log hook calls for debugging (can be disabled in production by removing console.debug)
+        // if (typeof console !== 'undefined' && console.debug) {
+        //   console.debug(
+        //     `[multi-step-form] Hook "${key}" called successfully`,
+        //     { result: result === undefined ? 'defined' : 'undefined' }
+        //   );
+        // }
+      } catch (error) {
+        // Provide helpful error message if hook throws
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+
+        throw new Error(
+          `[multi-step-form] Error calling hook "${key}" in useFormInstance.render: ${errorMessage}\n\n` +
+            `This usually means:\n` +
+            `1. The hook is being called outside of a React component\n` +
+            `2. The hook has invalid dependencies or configuration\n` +
+            `3. There's an error in your hook implementation\n\n` +
+            `Original error: ${errorMessage}`,
+          { cause: error }
+        );
+      }
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
This PR brings reactive support to `defaultValue` and `ctx` (via new `<Selector />` component) inside `createComponent`

closes #99

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces reactive form data, deep-key updates, and a richer API across core and React packages, plus CI/release tooling updates.
> 
> - **React**
>   - Makes step data reactive in `createComponent`; adds `<Selector />` component and `useSelector` for reactive reads
>   - Enhances `<Field />`: supports deep `name` paths; `defaultValue`/`onInputChange` work with deep values; adds per-field `reset`
>   - Fixes `createComponent` context issues (e.g., `ctx.stepX` undefined, formInstance+ctxData input wiring)
> - **Core**
>   - Adds `update` modes: `partial` and `strict` (with default error silencing when partial or non-strict); improves deep path normalization
>   - Adds convenient `reset` API and `resetFn` in helper functions; prevents extra keys on `reset`
>   - Refactors internals, exports `createStep`, `VALIDATED_STEP_REGEX`, `isValidStepKey`; storage fixes and option to throw when `window` is undefined
> - **Repo/Tooling**
>   - Renames core package to `@jfdevelops/multi-step-form-core`; switches builds to `tsdown`
>   - New CI (split core/react with artifacts), integration/versioning, and release workflows; improved pre-commit and Changesets config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5dfe62b00075ae9ab99f77fc22b681e940e7ec6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->