### PR TITLE
[fix] reduce playwright install overhead in react ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('packages/react/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
         working-directory: packages/react
-        run: pnpm exec playwright install --with-deps chromium
+        run: pnpm exec playwright install chromium
 
       # 2. UPDATED: Output to XML for React tests as well
       - name: Run tests (react)


### PR DESCRIPTION
## What changed
- changed the Playwright browser cache key to use `packages/react/package.json` instead of the full lockfile
- added a restore key for the Playwright browser cache
- removed `--with-deps` from the React Playwright install step

## Why
The React release job was spending excessive time in browser installation after unrelated lockfile churn invalidated the cache. This keeps the cache tied to the React package's Playwright version and avoids the heaviest install path on each run.

## Impact
This should make the React CI workflow reach the test step more reliably and reduce cold-start overhead on release runs.

## Validation
- commit hook skipped tests because only workflow files changed
- commit hook ran package builds successfully