### PR TITLE
[fix] run react ci tests without playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,18 +84,6 @@ jobs:
           name: core-build
           path: packages/core/dist
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('packages/react/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Install Playwright browsers
-        working-directory: packages/react
-        run: pnpm exec playwright install chromium
-
       # 2. UPDATED: Output to XML for React tests as well
       - name: Run tests (react)
         working-directory: packages/react

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,7 @@
     "@vitest/browser-playwright": "^4.0.8",
     "playwright": "^1.56.1",
     "react": "^19.1.1",
+    "react-dom": "^19.1.1",
     "tw-animate-css": "^1.4.0",
     "vite": "^7.1.5",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -3,15 +3,70 @@ import type {
   StepNumbers,
   StrippedResolvedStep,
 } from '@jfdevelops/multi-step-form-core';
-import { ComponentPropsWithRef } from 'react';
-import { describe, expect, it, test, vi } from 'vitest';
-import { render } from 'vitest-browser-react';
+import { ComponentPropsWithRef, type ReactElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, test, vi } from 'vitest';
 import {
   createMultiStepFormSchema,
   type CreateStepSpecificComponentCallback,
   type MultiStepFormSchema,
   type StepSpecificComponent,
 } from '../../src';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+afterEach(async () => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
+});
+
+async function renderInJsdom(ui: ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  mountedRoots.push({ container, root });
+
+  await act(async () => {
+    root.render(ui);
+  });
+
+  return {
+    getByTestId(testId: string) {
+      const element = container.querySelector<HTMLElement>(
+        `[data-testid="${testId}"]`,
+      );
+
+      if (!element) {
+        throw new Error(`Unable to find element by test id: ${testId}`);
+      }
+
+      return element;
+    },
+    getByText(text: string) {
+      const candidates = [
+        container,
+        ...Array.from(container.querySelectorAll<HTMLElement>('*')),
+      ];
+      const element = candidates.find((candidate) =>
+        candidate.textContent?.includes(text),
+      );
+
+      if (!element) {
+        throw new Error(`Unable to find element with text: ${text}`);
+      }
+
+      return element as HTMLElement;
+    },
+  };
+}
 
 describe('creating components via "createComponent" fn', () => {
   describe('using step specific "createComponent" fn', () => {
@@ -79,7 +134,7 @@ describe('creating components via "createComponent" fn', () => {
 
       expect(Step1).toBeTypeOf('function');
 
-      const screen = await render(<Step1 />);
+      const screen = await renderInJsdom(<Step1 />);
 
       const lastCall = componentSpy.mock.lastCall;
 
@@ -91,9 +146,7 @@ describe('creating components via "createComponent" fn', () => {
       expect(ctx).toHaveProperty('step1');
       expect(Object.keys(ctx)).toEqual(['step1']);
 
-      await expect
-        .element(screen.getByText('Step 1 Title: First step'))
-        .toBeInTheDocument();
+      expect(screen.getByText('Step 1 Title: First step')).toBeDefined();
     });
 
     it.skip('should use the provided custom "ctx"', async () => {
@@ -163,7 +216,7 @@ describe('creating components via "createComponent" fn', () => {
       expect(schema.stepSchema.value.step1.nameTransformCasing).toBe('flat');
       expect(Step1).toBeTypeOf('function');
 
-      const screen = await render(<Step1 />);
+      const screen = await renderInJsdom(<Step1 />);
 
       // ctxData assertions
       const lastCtxDataCall = ctxDataSpy.mock.lastCall;
@@ -188,9 +241,7 @@ describe('creating components via "createComponent" fn', () => {
       expect(Object.keys(ctx)).toEqual(['step1', 'step2']);
 
       // render assertions
-      await expect
-        .element(screen.getByText('Step 1 Title: First step'))
-        .toBeInTheDocument();
+      expect(screen.getByText('Step 1 Title: First step')).toBeDefined();
     });
 
     it('should use "onInputChange" to update a value for the specified field', async () => {
@@ -251,7 +302,7 @@ describe('creating components via "createComponent" fn', () => {
 
       expect(Step1).toBeTypeOf('function');
 
-      const screen = await render(<Step1 />);
+      const screen = await renderInJsdom(<Step1 />);
 
       const lastCall = componentSpy.mock.lastCall;
 
@@ -263,9 +314,7 @@ describe('creating components via "createComponent" fn', () => {
       expect(ctx).toHaveProperty('step1');
       expect(Object.keys(ctx)).toEqual(['step1']);
 
-      await expect
-        .element(screen.getByText('Step 1 Title: First step'))
-        .toBeInTheDocument();
+      expect(screen.getByText('Step 1 Title: First step')).toBeDefined();
 
       expect(onInputChange).toBeDefined();
       onInputChange({
@@ -318,16 +367,14 @@ describe('creating components via "createComponent" fn', () => {
           spy as never,
         );
 
-        const screen = await render(<Step1 />);
+        const screen = await renderInJsdom(<Step1 />);
 
         const lastCall = spy.mock.lastCall;
         expect(lastCall).toBeDefined();
         expect(lastCall![0].Form).toBeTypeOf('function');
 
-        await expect
-          .element(screen.getByTestId('injected-form'))
-          .toBeInTheDocument();
-        await expect.element(screen.getByText('content')).toBeInTheDocument();
+        expect(screen.getByTestId('injected-form')).toBeDefined();
+        expect(screen.getByText('content')).toBeDefined();
       });
 
       it('renders correctly when the step component uses the injected Form', async () => {
@@ -347,14 +394,10 @@ describe('creating components via "createComponent" fn', () => {
           ),
         );
 
-        const screen = await render(<Step1 />);
+        const screen = await renderInJsdom(<Step1 />);
 
-        await expect
-          .element(screen.getByTestId('form-renders-correctly'))
-          .toBeInTheDocument();
-        await expect
-          .element(screen.getByTestId('form-inner-child'))
-          .toBeInTheDocument();
+        expect(screen.getByTestId('form-renders-correctly')).toBeDefined();
+        expect(screen.getByTestId('form-inner-child')).toBeDefined();
       });
 
       it('injects the Form under a custom alias', async () => {
@@ -377,7 +420,7 @@ describe('creating components via "createComponent" fn', () => {
           spy as never,
         );
 
-        const screen = await render(<Step1 />);
+        const screen = await renderInJsdom(<Step1 />);
 
         const lastCall = spy.mock.lastCall;
         expect(lastCall).toBeDefined();
@@ -385,9 +428,7 @@ describe('creating components via "createComponent" fn', () => {
         // default 'Form' key should not be set when a custom alias is used
         expect(lastCall![0].Form).toBeUndefined();
 
-        await expect
-          .element(screen.getByTestId('alias-form'))
-          .toBeInTheDocument();
+        expect(screen.getByTestId('alias-form')).toBeDefined();
       });
 
       it('injects Form into all steps when enabledForSteps is "all"', async () => {
@@ -414,12 +455,12 @@ describe('creating components via "createComponent" fn', () => {
           step2Spy as never,
         );
 
-        await render(<Step1 />);
+        await renderInJsdom(<Step1 />);
         const step1LastCall = step1Spy.mock.lastCall;
         expect(step1LastCall).toBeDefined();
         expect(step1LastCall![0].Form).toBeTypeOf('function');
 
-        await render(<Step2 />);
+        await renderInJsdom(<Step2 />);
         const step2LastCall = step2Spy.mock.lastCall;
         expect(step2LastCall).toBeDefined();
         expect(step2LastCall![0].Form).toBeTypeOf('function');

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -4,22 +4,26 @@ import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vite';
 import packageJson from './package.json';
 
+const useBrowserMode = process.env.VITEST_BROWSER === '1';
+
 export default defineConfig({
   test: {
     name: packageJson.name,
     environment: 'jsdom',
-    browser: {
-      enabled: true,
-      provider: playwright({
-        launchOptions: {
-          args: ['--window-size=1280,720', '--window-position=100,100'],
-        },
-      }),
-      instances: [
-        {
-          browser: 'chromium',
-        },
-      ],
-    },
+    browser: useBrowserMode
+      ? {
+          enabled: true,
+          provider: playwright({
+            launchOptions: {
+              args: ['--window-size=1280,720', '--window-position=100,100'],
+            },
+          }),
+          instances: [
+            {
+              browser: 'chromium',
+            },
+          ],
+        }
+      : undefined,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       react:
         specifier: ^19.1.1
         version: 19.2.0
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.0(react@19.2.0)
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -2854,6 +2857,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
## What changed
- rewrote the React component test file to use jsdom rendering instead of `vitest-browser-react`
- made Vitest browser mode opt-in via `VITEST_BROWSER=1` instead of always enabled
- added `react-dom` to the React package dev dependencies for the jsdom test renderer
- removed Playwright browser cache/install steps from the default React CI workflow

## Why
The default React CI path was blocked on Playwright browser installation before tests even started. These tests can run in jsdom, so the CI workflow should not depend on Playwright provisioning just to execute the package test suite.

## Impact
CI should now run the React tests directly in jsdom without downloading Chromium. Browser-backed Vitest mode remains available locally as an opt-in path.

## Validation
- `pnpm run test:react -- --run`
- pre-commit hook ran `pnpm test:packages`
- pre-commit hook ran `pnpm run build:packages`