### PR TITLE
fix(react): resolve current step data lookup (189)

### DIFF
--- a/.changeset/bright-forms-update.md
+++ b/.changeset/bright-forms-update.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: rerender form context consumers after step data updates (#189)

--- a/.changeset/calm-forms-render.md
+++ b/.changeset/calm-forms-render.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: resolve current step data from form context (#189)

--- a/packages/react/src/create-context.tsx
+++ b/packages/react/src/create-context.tsx
@@ -276,7 +276,11 @@ export function createMultiStepFormContext<
       } as never;
     }
 
-    if (MultiStepFormStepSchema.hasData(data)) {
+    if (
+      MultiStepFormStepSchema.hasData({
+        [targetStep]: data,
+      })
+    ) {
       return {
         data,
         hasData: true,

--- a/packages/react/src/hooks/use-multi-step-form-data.ts
+++ b/packages/react/src/hooks/use-multi-step-form-data.ts
@@ -32,10 +32,6 @@ export type UseMultiStepFormData<
   <data>(selector: (schema: MultiStepFormSchema<def, value>) => data): data;
 };
 
-function noopSubscribe() {
-  return () => {};
-}
-
 export function createMultiStepFormDataHook<
   def extends StepSchema.Config,
   value extends instantiateReactSteps<def>
@@ -45,9 +41,16 @@ export function createMultiStepFormDataHook<
       | UseMultiStepFormDataOptions<StepNumbers<value>>
       | ((data: MultiStepFormSchema<def, value>) => unknown)
   ) {
-    return createUseSelector(
-      optionsOrSelector ? () => optionsOrSelector : noopSubscribe,
-      schema.subscribe
+    const selector =
+      typeof optionsOrSelector === 'function'
+        ? optionsOrSelector
+        : typeof optionsOrSelector === 'object' && optionsOrSelector !== null
+          ? (data: MultiStepFormSchema<def, value>) =>
+              data.stepSchema.value[optionsOrSelector.targetStep]
+          : (data: MultiStepFormSchema<def, value>) => data;
+
+    return createUseSelector(() => schema as never, schema.subscribe)(
+      selector as never
     );
   }
 

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -85,6 +85,9 @@ export class MultiStepFormSchema<
     super(options);
 
     this.stepSchema = new MultiStepFormStepSchema(options);
+    this.stepSchema.subscribe(() => {
+      this.notify();
+    });
     // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
     this.#internal = new MultiStepFormStepSchemaInternal<def, value>({
       originalValue: this.stepSchema.original,

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -63,7 +63,7 @@ export class MultiStepFormSchema<
     StepSchema.inferStorageKey<def>
   >;
 
-  readonly context: MultiStepFormContextResult<def, value> = undefined as never;
+  context: MultiStepFormContextResult<def, value> = undefined as never;
   readonly #formConfig: MultiStepFormSchemaConfig.FormConfig<def, value> =
     undefined as never;
 
@@ -164,9 +164,7 @@ export class MultiStepFormSchema<
   }
 
   withContext() {
-    const context = createMultiStepFormContext(this as never);
-
-    return new MultiStepFormSchema<def, value>({
+    const next = new MultiStepFormSchema<def, value>({
       steps: this.stepSchema.original,
       form: this.#formConfig,
       nameTransformCasing: this.stepSchema.defaultNameTransformationCasing,
@@ -175,8 +173,11 @@ export class MultiStepFormSchema<
         store: this.storageConfig.store,
         throwWhenUndefined: this.storageConfig.throwWhenUndefined,
       },
-      context,
     } as never);
+
+    next.context = createMultiStepFormContext(next as never);
+
+    return next;
   }
 
   createComponent<

--- a/packages/react/test/create-context.test.tsx
+++ b/packages/react/test/create-context.test.tsx
@@ -1,0 +1,104 @@
+import { ComponentPropsWithRef, type ReactElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMultiStepFormSchema } from '../src';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+afterEach(async () => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
+});
+
+async function renderInJsdom(ui: ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  mountedRoots.push({ container, root });
+
+  await act(async () => {
+    root.render(ui);
+  });
+
+  return {
+    getByText(text: string) {
+      const candidates = [
+        container,
+        ...Array.from(container.querySelectorAll<HTMLElement>('*')),
+      ];
+      const element = candidates.find((candidate) =>
+        candidate.textContent?.includes(text),
+      );
+
+      if (!element) {
+        throw new Error(`Unable to find element with text: ${text}`);
+      }
+
+      return element as HTMLElement;
+    },
+  };
+}
+
+describe('createMultiStepFormContext', () => {
+  it('returns the target step data through useCurrentStepData when using withForm', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        },
+        step2: {
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        },
+      },
+    })
+      .withForm({
+        render() {
+          return (props: ComponentPropsWithRef<'form'>) => (
+            <form {...props} />
+          );
+        },
+      })
+      .withContext();
+
+    schema.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Taylor',
+    });
+
+    const { useCurrentStepData } = schema.context;
+
+    function TestComponent() {
+      const { data, hasData, NoCurrentData } = useCurrentStepData({
+        targetStep: 'step1',
+      });
+
+      if (!hasData) {
+        return <NoCurrentData />;
+      }
+
+      return <p>First name: {data.fields.firstName.defaultValue}</p>;
+    }
+
+    const screen = await renderInJsdom(<TestComponent />);
+
+    expect(screen.getByText('First name: Taylor')).toBeDefined();
+  });
+});

--- a/packages/react/test/create-context.test.tsx
+++ b/packages/react/test/create-context.test.tsx
@@ -48,7 +48,7 @@ async function renderInJsdom(ui: ReactElement) {
 }
 
 describe('createMultiStepFormContext', () => {
-  it('returns the target step data through useCurrentStepData when using withForm', async () => {
+  it('rerenders current step data after a public step update', async () => {
     const schema = createMultiStepFormSchema({
       steps: {
         step1: {
@@ -78,11 +78,6 @@ describe('createMultiStepFormContext', () => {
       })
       .withContext();
 
-    schema.stepSchema.value.step1.update({
-      fields: ['fields.firstName.defaultValue'],
-      updater: 'Taylor',
-    });
-
     const { useCurrentStepData } = schema.context;
 
     function TestComponent() {
@@ -94,10 +89,17 @@ describe('createMultiStepFormContext', () => {
         return <NoCurrentData />;
       }
 
-      return <p>First name: {data.fields.firstName.defaultValue}</p>;
+      return <p>First name: {data.fields.firstName?.defaultValue}</p>;
     }
 
     const screen = await renderInJsdom(<TestComponent />);
+
+    await act(async () => {
+      schema.stepSchema.value.step1.update({
+        fields: ['fields.firstName.defaultValue'],
+        updater: 'Taylor',
+      });
+    });
 
     expect(screen.getByText('First name: Taylor')).toBeDefined();
   });


### PR DESCRIPTION
## Summary
- normalize `useMultiStepFormData({ targetStep })` into an actual selector and execute the selector hook immediately
- validate `useCurrentStepData` against the expected single-step shape so existing data does not fall through to the not-found branch
- bind `withContext()` to the returned schema instance and add a regression test for `withForm().withContext().useCurrentStepData(...)`

## Testing
- `pnpm exec vitest run --pool threads test/create-context.test.tsx test/step-schema/create-component.test.tsx`

Closes #189