### PR TITLE
fix(react): rerender whole-schema subscribers (189)

### DIFF
--- a/.changeset/fresh-forms-render.md
+++ b/.changeset/fresh-forms-render.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: rerender whole-schema consumers after form data updates (#189)

--- a/packages/react/src/hooks/use-multi-step-form-data.ts
+++ b/packages/react/src/hooks/use-multi-step-form-data.ts
@@ -41,17 +41,21 @@ export function createMultiStepFormDataHook<
       | UseMultiStepFormDataOptions<StepNumbers<value>>
       | ((data: MultiStepFormSchema<def, value>) => unknown)
   ) {
+    const shouldReturnWholeSchema = optionsOrSelector === undefined;
     const selector =
       typeof optionsOrSelector === 'function'
         ? optionsOrSelector
         : typeof optionsOrSelector === 'object' && optionsOrSelector !== null
           ? (data: MultiStepFormSchema<def, value>) =>
               data.stepSchema.value[optionsOrSelector.targetStep]
-          : (data: MultiStepFormSchema<def, value>) => data;
+          : (data: MultiStepFormSchema<def, value>) => data.stepSchema.value;
 
-    return createUseSelector(() => schema as never, schema.subscribe)(
-      selector as never
-    );
+    const selected = createUseSelector(
+      () => schema as never,
+      schema.subscribe
+    )(selector as never);
+
+    return shouldReturnWholeSchema ? schema : selected;
   }
 
   return useMultiStepFormData as any;

--- a/packages/react/test/create-context.test.tsx
+++ b/packages/react/test/create-context.test.tsx
@@ -48,7 +48,7 @@ async function renderInJsdom(ui: ReactElement) {
 }
 
 describe('createMultiStepFormContext', () => {
-  it('rerenders current step data after a public step update', async () => {
+  it('rerenders current and whole data after a public step update', async () => {
     const schema = createMultiStepFormSchema({
       steps: {
         step1: {
@@ -78,9 +78,10 @@ describe('createMultiStepFormContext', () => {
       })
       .withContext();
 
-    const { useCurrentStepData } = schema.context;
+    const { useCurrentStepData, useMultiStepFormData } = schema.context;
 
     function TestComponent() {
+      const wholeSchema = useMultiStepFormData();
       const { data, hasData, NoCurrentData } = useCurrentStepData({
         targetStep: 'step1',
       });
@@ -89,7 +90,18 @@ describe('createMultiStepFormContext', () => {
         return <NoCurrentData />;
       }
 
-      return <p>First name: {data.fields.firstName?.defaultValue}</p>;
+      return (
+        <>
+          <p>Current step: {data.fields.firstName?.defaultValue}</p>
+          <p>
+            Whole schema:{' '}
+            {
+              wholeSchema.stepSchema.value.step1.fields.firstName
+                ?.defaultValue
+            }
+          </p>
+        </>
+      );
     }
 
     const screen = await renderInJsdom(<TestComponent />);
@@ -101,6 +113,7 @@ describe('createMultiStepFormContext', () => {
       });
     });
 
-    expect(screen.getByText('First name: Taylor')).toBeDefined();
+    expect(screen.getByText('Current step: Taylor')).toBeDefined();
+    expect(screen.getByText('Whole schema: Taylor')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- observe `stepSchema.value` as the changing snapshot for the no-argument `useMultiStepFormData()` overload
- preserve the documented return value as the original `MultiStepFormSchema` instance
- cover targeted and whole-schema consumers rerendering after a public step update
- add a patch changeset for `@jfdevelops/react-multi-step-form`

## Testing
- `pnpm exec vitest run --no-cache test/create-context.test.tsx`
- `pnpm exec changeset status`

## Typecheck
- `pnpm typecheck` still reports the two pre-existing unused declarations in `src/schema.ts` and `src/step-schema.ts`

Follow-up to #190. Related to #189.