### PR TITLE
refactor(react): remove useFormInstance from createComponent and type Form by default

### DIFF
--- a/.changeset/remove-use-form-instance.md
+++ b/.changeset/remove-use-form-instance.md
@@ -1,0 +1,10 @@
+---
+'@jfdevelops/react-multi-step-form': minor
+---
+
+refactor: remove `useFormInstance` from `createComponent` and type `Form` by default
+
+- Removes the `useFormInstance` option from the second `createComponent` overload — the `Form` component from an external form library can now be composed manually in the callback instead
+- `Form` (the default `<form>` wrapper) is now always present in the `createComponent` callback type when no custom `withForm()` config is supplied, matching existing runtime behaviour
+- Simplifies `StepSpecificComponent.options` from 5 type params to 3
+- Removes `formInstanceOptions`, `DEFAULT_FORM_INSTANCE_ALIAS`, and `defaultFormInstanceAlias` from the public API

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -134,37 +134,6 @@ export class MultiStepFormStepSchema<
     });
   }
 
-  private createFormComponent(
-    form: Omit<MultiStepFormSchemaConfig.FormConfig<def, value>, 'alias'>,
-    defaultId: string
-  ) {
-    const { render, enabledForSteps = 'all', id = defaultId } = form;
-
-    const ctx = {
-      id,
-      steps: createCtx(this.value, enabledForSteps as never),
-    };
-
-    return (props: MultiStepFormSchemaConfig.inferFormProps<value>) => {
-      const Component = render(ctx as never);
-      const invariant: Invariant = createInvariant('[createFormComponent]');
-
-      invariant(
-        typeof Component === 'function',
-        'The "render" property must be a function'
-      );
-
-      const C = Component(props);
-
-      invariant(
-        typeof C === 'function',
-        'The "render" function must return a valid React component'
-      );
-
-      return C;
-    };
-  }
-
   private createResolvedCtx<
     // Safe to use tuple notation here since the step specific `createComponent` will always have
     // `stepData` as a tuple
@@ -424,33 +393,11 @@ export class MultiStepFormStepSchema<
     targetStep: targetStep,
     config: CreateComponentImplConfig.stepSpecificConfig<def, value>
   ) {
-    const impl = <
-      formInstance,
-      formInstanceAlias extends string = StepSpecificComponent.defaultFormInstanceAlias,
-      additionalCtx extends Record<string, unknown> = {}
-    >(
+    const impl = <additionalCtx extends Record<string, unknown> = {}, props = undefined>(
       optionsOrFn:
-        | StepSpecificComponent.options<
-            value,
-            targetStep,
-            MultiStepFormSchemaConfig.inferFormAlias<value>,
-            formInstance,
-            additionalCtx
-          >
-        | StepSpecificComponent.callback<
-            def,
-            value,
-            targetStep,
-            MultiStepFormSchemaConfig.inferFormProps<value>,
-            { [_ in formInstanceAlias]: formInstance }
-          >,
-      fn?: StepSpecificComponent.callback<
-        def,
-        value,
-        targetStep,
-        MultiStepFormSchemaConfig.inferFormProps<value>,
-        { [_ in formInstanceAlias]: formInstance }
-      >
+        | StepSpecificComponent.options<value, targetStep, additionalCtx>
+        | StepSpecificComponent.callback<def, value, targetStep, props, additionalCtx>,
+      fn?: StepSpecificComponent.callback<def, value, targetStep, props, additionalCtx>
     ) => {
       const invariant: Invariant = createInvariant(
         '[createStepSpecificComponent]'
@@ -469,7 +416,7 @@ export class MultiStepFormStepSchema<
       };
 
       if (typeof optionsOrFn === 'object') {
-        const { useFormInstance, ctxData, debug } = optionsOrFn;
+        const { ctxData, debug } = optionsOrFn;
         const logger = new MultiStepFormLogger({
           debug,
           prefix(prefix) {
@@ -484,35 +431,6 @@ export class MultiStepFormStepSchema<
           'The second argument must be a function'
         );
 
-        if (useFormInstance) {
-          const {
-            render,
-            alias = StepSpecificComponent.DEFAULT_FORM_INSTANCE_ALIAS,
-          } = useFormInstance;
-
-          invariant(typeof alias === 'string', 'The alias must be a string');
-
-          // const [step] = stepData;
-
-          return this.createStepSpecificComponentImpl([targetStep], config, {
-            logger,
-            ctxData,
-            input: (ctx) => {
-              const defaultValues = this.createDefaultValues(
-                targetStep
-              ) as never;
-
-              return {
-                [alias]: () =>
-                  render({
-                    ctx,
-                    defaultValues,
-                  }),
-              };
-            },
-          })(fn);
-        }
-
         if (ctxData) {
           return this.createStepSpecificComponentImpl([targetStep], config, {
             logger,
@@ -520,8 +438,6 @@ export class MultiStepFormStepSchema<
           })(fn);
         }
 
-        // Empty options object. Can throw here 🤷‍♂️
-        // Maybe add "global" - top level config - option to tune fine grained errors.
         return createStepSpecificComponent();
       }
 

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -2,7 +2,6 @@ import type {
   _instantiateSteps,
   BaseStepFunctions,
   Expand,
-  getDefaultValues,
   HelperFn,
   HelperFnChosenSteps,
   HelperFnInput,
@@ -11,6 +10,7 @@ import type {
   UpdateFn,
 } from '@jfdevelops/multi-step-form-core';
 import { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
+import type { ComponentPropsWithRef } from 'react';
 import { field } from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { UseSelector } from './hooks/use-selector';
@@ -18,11 +18,18 @@ import { selector } from './selector';
 import { CreateComponent, CreatedMultiStepFormComponent } from './utils';
 
 export namespace StepSpecificComponent {
+  type defaultFormComponent = {
+    [key in MultiStepFormSchemaConfig.defaultFormAlias]: CreatedMultiStepFormComponent<
+      Omit<ComponentPropsWithRef<'form'>, 'id'>
+    >;
+  };
   type instantiateFormComponentForAllSteps<
     def extends StepSchema.Config,
     value = MultiStepFormSchemaConfig.instantiateFormConfig<def>
   > = MultiStepFormSchemaConfig.EnabledForSteps.get<value> extends MultiStepFormSchemaConfig.defaultEnabledFor
-    ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
+    ? keyof MultiStepFormSchemaConfig.instantiateFormConfig<def> extends never
+      ? defaultFormComponent
+      : MultiStepFormSchemaConfig.instantiateFormConfig<def>
     : {};
   type instantiateFormComponentForTuple<
     def extends StepSchema.Config,
@@ -148,60 +155,15 @@ export namespace StepSpecificComponent {
     >,
     props
   >;
-  export const DEFAULT_FORM_INSTANCE_ALIAS = 'form';
-  export type defaultFormInstanceAlias = typeof DEFAULT_FORM_INSTANCE_ALIAS;
-  export type formInstanceOptions<alias extends string, input, ret> = {
-    /**
-     * The name of the return value of the `render` method.
-     */
-    alias?: alias;
-    /**
-     * A function that renders/creates the form instance. This function will be called
-     * at the top level of the component, ensuring hooks are called in a valid React context.
-     *
-     * @param input - The input object containing context and default values
-     * @returns The form instance (typically from a hook like `useForm`)
-     *
-     * @example
-     * ```tsx
-     * useFormInstance: {
-     *   render({ defaultValues }) {
-     *     return useForm({
-     *       defaultValues,
-     *     });
-     *   },
-     * }
-     * ```
-     *
-     * **Verification**: The hook call is automatically verified:
-     * - Errors are caught and reported with helpful messages
-     * - In development, hook calls are logged to console.debug
-     * - The hook must be called at the component top level (enforced by the framework)
-     */
-    render: (input: input) => ret;
-  };
-
   export type options<
     value extends instantiateReactSteps,
     targetStep extends StepNumbers<value>,
-    formAlias extends string,
-    formInstance,
     additionalCtx extends Record<string, unknown> = {}
   > = HelperFn.CtxDataSelector<value, [targetStep], additionalCtx> & {
     /**
      * If set to `true`, you'll be able to open the {@linkcode console} to view logs.
      */
     debug?: boolean;
-    useFormInstance?: formInstanceOptions<
-      formAlias,
-      Pick<HelperFnInput.BaseInput<value, [targetStep]>, 'ctx'> & {
-        /**
-         * An object containing all the default values for the current step.
-         */
-        defaultValues: Expand<getDefaultValues<value, targetStep>>;
-      },
-      formInstance
-    >;
   };
 }
 
@@ -223,26 +185,9 @@ export interface StepSpecificCreateComponentFn<
    * @param fn The callback function where the component is defined.
    * @returns The created component.
    */
-  <
-    formInstance,
-    additionalCtx extends Record<string, unknown> = {},
-    formInstanceAlias extends string = StepSpecificComponent.defaultFormInstanceAlias,
-    props = undefined
-  >(
-    options: StepSpecificComponent.options<
-      value,
-      targetStep,
-      MultiStepFormSchemaConfig.inferFormAlias<value>,
-      formInstance,
-      additionalCtx
-    >,
-    fn: StepSpecificComponent.callback<
-      def,
-      value,
-      targetStep,
-      MultiStepFormSchemaConfig.inferFormProps<value>,
-      { [_ in formInstanceAlias]: formInstance }
-    >
+  <additionalCtx extends Record<string, unknown> = {}, props = undefined>(
+    options: StepSpecificComponent.options<value, targetStep, additionalCtx>,
+    fn: StepSpecificComponent.callback<def, value, targetStep, props, additionalCtx>
   ): CreatedMultiStepFormComponent<props>;
 }
 

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -13,8 +13,9 @@ import {
   type StepSpecificComponent,
 } from '../../src';
 
-(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
-  .IS_REACT_ACT_ENVIRONMENT = true;
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
 
@@ -197,8 +198,6 @@ describe('creating components via "createComponent" fn', () => {
           StepSpecificComponent.options<
             ResolvedStep,
             'step1',
-            MultiStepFormSchemaConfig.defaultFormAlias,
-            unknown,
             { step2: StrippedResolvedStep<ResolvedStep['step2'], false> }
           >['ctxData'],
           undefined


### PR DESCRIPTION
## Summary

- Removes the `useFormInstance` option from the second `createComponent` overload — including its runtime branch, `createFormComponent` private method, `formInstanceOptions` type, `DEFAULT_FORM_INSTANCE_ALIAS`, and `defaultFormInstanceAlias`
- `Form` is now always present in the step-component callback type when no custom `withForm()` config is provided, matching the existing runtime behaviour (a default `<form>` element was always injected but the type didn't reflect it)
- Simplifies `StepSpecificComponent.options` from 5 type params to 3, and the second overload of `StepSpecificCreateComponentFn` from 4 to 2

## Test plan

- [ ] All existing `create-component` tests pass (6 passing, 1 skipped, 3 todo)
- [ ] TypeScript reports no new errors beyond the pre-existing `schema.ts` unused variable
- [ ] `Form` is accessible and correctly typed in the `createComponent` callback without needing `withForm()`