### PR TITLE
feat(react): expose defaultValues in createComponent callback

### DIFF
--- a/.changeset/expose-default-values-in-create-component.md
+++ b/.changeset/expose-default-values-in-create-component.md
@@ -1,0 +1,7 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+feat: expose `defaultValues` in `createComponent` callback
+
+`defaultValues` is now available directly in the `createComponent` callback, providing the same flat map of field default values that was previously only accessible via the removed `useFormInstance.render` input.

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -342,6 +342,7 @@ export class MultiStepFormStepSchema<
           Field,
           useSelector,
           Selector,
+          defaultValues: this.createDefaultValues(step as never) as never,
           ...hookResults,
         };
 

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -2,6 +2,7 @@ import type {
   _instantiateSteps,
   BaseStepFunctions,
   Expand,
+  getDefaultValues,
   HelperFn,
   HelperFnChosenSteps,
   HelperFnInput,
@@ -139,6 +140,11 @@ export namespace StepSpecificComponent {
        * </Selector>
        */
       Selector: selector.component<buildCurrentStep<def, value, targetStep>>;
+      /**
+       * An object containing the default values for every field in the current step,
+       * as defined in the schema config.
+       */
+      defaultValues: Expand<getDefaultValues<value, targetStep>>;
     };
 
   export type callback<


### PR DESCRIPTION
## Summary

- `defaultValues` is now available in the `createComponent` callback alongside `ctx`, `Field`, `onInputChange`, etc.
- Provides the same flat map of field default values that was previously only accessible via the removed `useFormInstance.render` input
- Patch bump for `@jfdevelops/react-multi-step-form`

## Test plan

- [ ] Existing `create-component` tests continue to pass
- [ ] `defaultValues` is correctly typed as `Expand<getDefaultValues<value, targetStep>>` in the callback
- [ ] TypeScript reports no new errors