### PR TITLE
feat(react): expose defaultValues in createComponent callback

### DIFF
--- a/.changeset/expose-default-values-in-create-component.md
+++ b/.changeset/expose-default-values-in-create-component.md
@@ -1,0 +1,7 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+feat: expose `defaultValues` in `createComponent` callback
+
+`defaultValues` is now available directly in the `createComponent` callback, providing the same flat map of field default values that was previously only accessible via the removed `useFormInstance.render` input.

--- a/packages/react/src/form-config.tsx
+++ b/packages/react/src/form-config.tsx
@@ -81,16 +81,25 @@ export namespace MultiStepFormSchemaConfig {
 
   export type instantiateFormConfig<def> = [def] extends [object]
     ? def extends { form: infer form }
-      ? {
-          -readonly [key in keyof FormConfig.withoutRender<form>]: Expand<
+      ? [form] extends [never]
+        ? never
+        : keyof FormConfig.withoutRender<form> extends never
+        ? Expand<
             {
-              alias: inferFormAlias<FormConfig.withoutRender<form>>;
-              enabledForSteps: inferFormEnabledForSteps<
-                FormConfig.withoutRender<form>
-              >;
+              alias: inferFormAlias<form>;
+              enabledForSteps: inferFormEnabledForSteps<form>;
             } & inferredFormComponent<form>
-          >;
-        }[keyof FormConfig.withoutRender<form>]
+          >
+        : {
+            -readonly [key in keyof FormConfig.withoutRender<form>]: Expand<
+              {
+                alias: inferFormAlias<FormConfig.withoutRender<form>>;
+                enabledForSteps: inferFormEnabledForSteps<
+                  FormConfig.withoutRender<form>
+                >;
+              } & inferredFormComponent<form>
+            >;
+          }[keyof FormConfig.withoutRender<form>]
       : {}
     : {};
   export type getEnabledForSteps<def> = instantiateFormConfig<def> extends {

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -342,6 +342,7 @@ export class MultiStepFormStepSchema<
           Field,
           useSelector,
           Selector,
+          defaultValues: this.createDefaultValues(step as never) as never,
           ...hookResults,
         };
 

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -52,11 +52,11 @@ export interface HelperFunctions<
 namespace CreateComponentImplConfig {
   export type stepSpecificConfig<
     def extends StepSchema.Config,
-    value extends instantiateReactSteps<def>
+    _value extends instantiateReactSteps<def>
   > = {
     isStepSpecific: true;
     defaultId: string;
-    form?: MultiStepFormSchemaConfig.FormConfig<def, value>;
+    form?: Record<string, unknown>;
   };
 
   export type nonStepSpecific = {

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -2,6 +2,7 @@ import type {
   _instantiateSteps,
   BaseStepFunctions,
   Expand,
+  getDefaultValues,
   HelperFn,
   HelperFnChosenSteps,
   HelperFnInput,
@@ -139,6 +140,11 @@ export namespace StepSpecificComponent {
        * </Selector>
        */
       Selector: selector.component<buildCurrentStep<def, value, targetStep>>;
+      /**
+       * An object containing the default values for every field in the current step,
+       * as defined in the schema config.
+       */
+      defaultValues: Expand<getDefaultValues<value, targetStep>>;
     };
 
   export type callback<


### PR DESCRIPTION
## Summary

- Exposes `defaultValues` in the `createComponent` callback so consumers can access pre-typed default field values directly without deriving them from `ctx`
- Fixes a regression where `Form` was typed as the generic HTML form element instead of the user's custom form component when `withForm()` was called with only `render` (no `alias`/`enabledForSteps`)
- Corrects `stepSpecificConfig.form` internal type from `FormConfig<def, value>` (which incorrectly included `render`) to `Record<string, unknown>`, matching what is actually stored after form instantiation

## Root cause of the Form regression

When `withForm({ render(...) { ... } })` is used without `alias` or `enabledForSteps`, `FormConfig.withoutRender<form>` collapses to `{}`. The mapped type `{ [key in keyof {}]: ... }[never]` evaluates to `never`, which then satisfied `keyof never extends never` in `instantiateFormComponentForAllSteps`, causing the type to fall back to `defaultFormComponent` (the generic HTML form) instead of inferring the user's custom component.

The fix detects the render-only case and builds the instantiated form config directly from `form`, correctly picking up the custom component type via `inferComponent<form>`.

## Test plan

- [ ] Verify `defaultValues` is available and correctly typed in `createComponent` callbacks
- [ ] Verify `Form` is typed as the custom component (with custom props) when using `withForm({ render(...) { ... } })` without `alias`
- [ ] Verify `Form` still types correctly when `alias` and/or `enabledForSteps` are provided alongside `render`
- [ ] Run existing test suite — all passing tests should remain green