### PR TITLE
fix(react): restore withForm form inference

### DIFF
--- a/.changeset/fix-custom-form-type-in-create-component.md
+++ b/.changeset/fix-custom-form-type-in-create-component.md
@@ -1,0 +1,7 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: restore custom `Form` type in `createComponent` callback when using `withForm({ render })`
+
+When `withForm()` was called with only `render` (no `alias` or `enabledForSteps`), the `Form` parameter in the `createComponent` callback was incorrectly typed as the generic HTML form element instead of the user's custom form component. This has been fixed.

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -148,8 +148,8 @@ export class MultiStepFormSchema<
    * @returns A new {@linkcode MultiStepFormSchema} with the form configuration.
    */
   withForm<
-    const formConfig extends MultiStepFormSchemaConfig.FormConfig<def, value>
-  >(config: formConfig) {
+    const formConfig extends object
+  >(config: formConfig & MultiStepFormSchemaConfig.FormConfig<def, value>) {
     const { key, store, throwWhenUndefined } = this.storageConfig;
 
     return new MultiStepFormSchema<
@@ -208,57 +208,3 @@ export function createMultiStepFormSchema<
 >(options: def) {
   return new MultiStepFormSchema<def, value>(options);
 }
-
-const schema = createMultiStepFormSchema({
-  steps: {
-    step1: {
-      title: 'Personal Information',
-      fields: {
-        firstName: {
-          defaultValue: '',
-        },
-        lastName: {
-          defaultValue: '',
-        },
-        email: {
-          defaultValue: '',
-          type: 'string.email',
-        },
-        phoneNumber: {
-          defaultValue: '',
-          type: 'string.phone',
-        },
-        dateOfBirth: {
-          defaultValue: new Date(),
-          type: 'date',
-        },
-      },
-    },
-    step2: {
-      title: 'Booking Details',
-      description: 'Who is getting makeup and what services do they want?',
-      fields: {
-        faces: {
-          defaultValue: {
-            min: 1,
-            max: 10,
-            faces: [],
-          },
-        },
-        totals: {
-          defaultValue: {
-            running: {
-              duration: 0,
-              cost: 0,
-            },
-            itemized: {},
-          },
-        },
-      },
-    },
-  },
-});
-
-// const Step1 = schema.stepSchema.value.step1.createComponent(function Test({
-//   ctx,
-// }) {});

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -173,6 +173,13 @@ export namespace StepSpecificComponent {
   };
 }
 
+type LegacyFormComponent<
+  alias extends string,
+  formProps
+> = string extends alias
+  ? {}
+  : MultiStepFormSchemaConfig.formCtx<alias, formProps>;
+
 export interface StepSpecificCreateComponentFn<
   def extends StepSchema.Config,
   value extends instantiateReactSteps<def>,
@@ -216,6 +223,7 @@ export type CreateStepSpecificComponentCallback<
   Expand<
     HelperFnInput.BaseInput<value, chosenSteps, never, additionalCtx> &
       StepSpecificComponent.updateWrappers<value, chosenSteps[0]> &
+      LegacyFormComponent<_formAlias, props> &
       additionalCtx
   >,
   props

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -3,7 +3,12 @@ import type {
   StepNumbers,
   StrippedResolvedStep,
 } from '@jfdevelops/multi-step-form-core';
-import { ComponentPropsWithRef, type ReactElement, act } from 'react';
+import {
+  ComponentPropsWithRef,
+  type ReactElement,
+  type ReactNode,
+  act,
+} from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, test, vi } from 'vitest';
 import {
@@ -374,6 +379,69 @@ describe('creating components via "createComponent" fn', () => {
 
         expect(screen.getByTestId('injected-form')).toBeDefined();
         expect(screen.getByText('content')).toBeDefined();
+      });
+
+      it('infers Form from the return type of withForm.render', () => {
+        type CustomFormProps = {
+          title: string;
+          children?: ReactNode;
+        };
+
+        const schema = makeBaseSchema().withForm({
+          render() {
+            return ({ title, children }: CustomFormProps) => (
+              <form aria-label={title}>{children}</form>
+            );
+          },
+        });
+
+        schema.stepSchema.value.step1.createComponent(({ Form }) => {
+          const TypedForm = Form;
+
+          // @ts-expect-error The custom form requires a title prop.
+          <TypedForm />;
+
+          return <TypedForm title='typed-form'>content</TypedForm>;
+        });
+      });
+
+      it('restores Form typing in CreateStepSpecificComponentCallback', () => {
+        type CustomFormProps = {
+          title: string;
+          children?: ReactNode;
+        };
+
+        const schema = makeBaseSchema().withForm({
+          render() {
+            return ({ title, children }: CustomFormProps) => (
+              <form aria-label={title}>{children}</form>
+            );
+          },
+        });
+
+        type ResolvedStep = MultiStepFormSchema.resolvedStep<typeof schema>;
+        type Steps = StepNumbers<ResolvedStep>;
+
+        const callback: CreateStepSpecificComponentCallback<
+          ResolvedStep,
+          Steps,
+          ['step1'],
+          undefined,
+          MultiStepFormSchemaConfig.defaultFormAlias,
+          CustomFormProps,
+          MultiStepFormSchemaConfig.defaultEnabledFor
+        > = ({ Form }) => {
+          // @ts-expect-error The custom form requires a title prop.
+          <Form />;
+
+          return <Form title='callback-typed-form'>content</Form>;
+        };
+
+        const Step1 = schema.stepSchema.value.step1.createComponent(
+          callback as never,
+        );
+
+        expect(Step1).toBeTypeOf('function');
       });
 
       it('renders correctly when the step component uses the injected Form', async () => {


### PR DESCRIPTION
## What changed
Restored `withForm()` type preservation so the exact component returned by `withForm.render` flows into step-specific `createComponent(...)` callbacks.

Also restored the exported `CreateStepSpecificComponentCallback` shape so `Form` is included again for consumers using that helper type directly.

## Why
After the `useFormInstance` removal, the form config was being widened too early and the exported callback alias no longer threaded the form component type through. That caused `Form` to fall back to the default `<form>` props instead of the custom props returned by `withForm.render`.

## Impact
Consumers now get the expected custom `Form` prop inference in both inline `step.createComponent(...)` callbacks and `CreateStepSpecificComponentCallback`-typed callbacks.

## Validation
- `pnpm --filter @jfdevelops/react-multi-step-form typecheck`
- `pnpm --filter @jfdevelops/react-multi-step-form exec vitest run test/step-schema/create-component.test.tsx --pool=threads --maxWorkers=1`
- pre-commit hook ran package tests and builds successfully