### PR TITLE
fix(field): omit disabled labels and refresh selector context

### DIFF
--- a/.changeset/green-fields-sync.md
+++ b/.changeset/green-fields-sync.md
@@ -1,0 +1,8 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: omit disabled field labels and restore reactive field selector props
+
+Disabled field labels are now omitted from the resolved field config and from React `Field` children props instead of being exposed as `false` or `undefined`. This also fixes React field selector children so `selected.value` updates with the latest form state.

--- a/packages/core/src/steps/fields.ts
+++ b/packages/core/src/steps/fields.ts
@@ -299,6 +299,16 @@ export type inferLabel<
   : undefined extends Casing
     ? ChangeCasing<FieldKey, DefaultCasing>
     : ChangeCasing<FieldKey, Exclude<Casing, undefined>>;
+
+type instantiateResolvedLabelProp<
+  T,
+  Casing extends CasingType | undefined,
+  FieldKey extends string,
+> = inferLabel<T, Casing, FieldKey> extends infer label
+  ? [label] extends [false]
+    ? {}
+    : { label: label }
+  : never;
 export type inferResolvedDateFieldType<T> = T extends {
   type: infer type extends DateFieldType;
 }
@@ -328,16 +338,11 @@ export type instantiateFields<
              */
             name: key;
           } & (key extends string
-            ? {
-                /**
-                 * The label for the field.
-                 */
-                label: inferLabel<
-                  T['fields'][key],
-                  inferNameTransformCasing<T['fields'][key], TDefaultCasing>,
-                  key
-                >;
-              }
+            ? instantiateResolvedLabelProp<
+                T['fields'][key],
+                inferNameTransformCasing<T['fields'][key], TDefaultCasing>,
+                key
+              >
             : {}) &
             (inferDefaultValue<T['fields'][key]> extends Date
               ? /**
@@ -360,6 +365,10 @@ export function createFieldLabel(
   fieldName: string,
   casingType: CasingType
 ) {
+  if (label === false) {
+    return undefined;
+  }
+
   return label ?? changeCasing(fieldName, casingType);
 }
 /**
@@ -420,7 +429,7 @@ export function instantiateFields<
     const sharedFields = {
       nameTransformCasing: casing,
       name,
-      label: resolvedLabel,
+      ...(resolvedLabel === undefined ? {} : { label: resolvedLabel }),
     };
 
     if (defaultValue instanceof Date) {

--- a/packages/core/test/step-schema/field-properties.test.ts
+++ b/packages/core/test/step-schema/field-properties.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { createMultiStepFormSchema } from '../../src';
+
+describe('multi step form step schema: field properties', () => {
+  it('resolves the standard field properties for string fields', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          nameTransformCasing: 'kebab',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+              label: 'Your first name',
+            },
+            lastName: {
+              defaultValue: 'Swift',
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema.stepSchema.value.step1.fields.firstName).toStrictEqual({
+      name: 'firstName',
+      defaultValue: 'Taylor',
+      label: 'Your first name',
+      nameTransformCasing: 'kebab',
+    });
+
+    expect(schema.stepSchema.value.step1.fields.lastName).toStrictEqual({
+      name: 'lastName',
+      defaultValue: 'Swift',
+      label: 'last-name',
+      nameTransformCasing: 'kebab',
+    });
+  });
+
+  it('omits a disabled label', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+              label: false,
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema.stepSchema.value.step1.fields.firstName).toStrictEqual({
+      name: 'firstName',
+      defaultValue: 'Taylor',
+      nameTransformCasing: 'title',
+    });
+    expect(schema.stepSchema.value.step1.fields.firstName).not.toHaveProperty(
+      'label',
+    );
+  });
+
+  it('resolves the type property for date fields', () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            createdAt: {
+              defaultValue: date,
+            },
+            startDate: {
+              defaultValue: date,
+              type: 'string',
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema.stepSchema.value.step1.fields.createdAt).toStrictEqual({
+      name: 'createdAt',
+      defaultValue: date,
+      label: 'Created At',
+      nameTransformCasing: 'title',
+      type: 'date',
+    });
+
+    expect(schema.stepSchema.value.step1.fields.startDate).toStrictEqual({
+      name: 'startDate',
+      defaultValue: JSON.stringify(date),
+      label: 'Start Date',
+      nameTransformCasing: 'title',
+      type: 'string',
+    });
+  });
+});

--- a/packages/core/test/step-schema/label.test.ts
+++ b/packages/core/test/step-schema/label.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createMultiStepFormSchema } from '../../src';
 
 describe('multi step form step schema: label', () => {
-  it('should have label=false when specified', () => {
+  it('should omit the label when set to false', () => {
     const schema = createMultiStepFormSchema({
       steps: {
         step1: {
@@ -18,9 +18,9 @@ describe('multi step form step schema: label', () => {
       },
     });
 
-    expect(
-      schema.stepSchema.get({ step: 'step1' }).data.fields.firstName.label
-    ).toBeFalsy();
+    expect(schema.stepSchema.get({ step: 'step1' }).data.fields.firstName).not.toHaveProperty(
+      'label'
+    );
   });
 
   it('should have a default label when no label is specified', () => {

--- a/packages/react/src/field.tsx
+++ b/packages/react/src/field.tsx
@@ -32,6 +32,15 @@ export namespace field {
   }> &
     UpdateFn.DebugOptions;
 
+  type normalizeChildrenConfig<TConfig, TValue> =
+    TConfig extends { defaultValue: unknown }
+      ? Override<TConfig, 'defaultValue', TValue> extends infer resolvedConfig
+        ? resolvedConfig extends { label: false }
+          ? Omit<resolvedConfig, 'label'>
+          : resolvedConfig
+        : never
+      : never;
+
   export type childrenProps<
     steps extends instantiateSteps,
     field extends getDeepFields<steps, targetStep>,
@@ -42,7 +51,7 @@ export namespace field {
     getFieldConfig<steps, targetStep, field>,
   > = sharedProps<field> &
     (TConfig extends { defaultValue: unknown }
-      ? Override<TConfig, 'defaultValue', value>
+      ? normalizeChildrenConfig<TConfig, value>
       : {
         defaultValue: `An unknown error occurred while getting the "defaultValue" for ${field}`;
       }) & {
@@ -114,7 +123,7 @@ export namespace field {
     >(
       name: field
     ) => resolveDeepFieldPath<step, StepNumbers<step>, field>;
-    selectorCtx: Expand<HelperFn.buildCtx<step, [StepNumbers<step>]>>;
+    selectorCtx: () => Expand<HelperFn.buildCtx<step, [StepNumbers<step>]>>;
   };
 
   /**
@@ -154,7 +163,7 @@ export namespace field {
       }
 
       if (selectorFn) {
-        const Selector = selector.create<step>(() => selectorCtx, subscribeFn);
+        const Selector = selector.create<step>(selectorCtx, subscribeFn);
 
         return (
           <Selector selector={selectorFn}>

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -260,18 +260,26 @@ export class MultiStepFormStepSchema<
 
             const defaultValue = this.getValue(step as never, name);
             const builtValuePath = buildValuePath(name);
-            const { label, nameTransformCasing, type } = path.pickBy(
-              currentStep.fields,
-              builtValuePath
-            );
+            const fieldName = String(name);
+            const [parentFieldName] = fieldName.split('.');
+            const fieldsRecord = currentStep.fields as Record<string, unknown>;
+            const {
+              label,
+              nameTransformCasing,
+              type,
+            } = fieldsRecord[parentFieldName] as {
+              label?: unknown;
+              nameTransformCasing?: unknown;
+              type?: unknown;
+            };
 
             const targetFields = `fields.${builtValuePath}`;
 
             return {
               defaultValue,
-              label,
+              ...(label === undefined ? {} : { label }),
               nameTransformCasing,
-              type,
+              ...(type === undefined ? {} : { type }),
               name,
               onInputChange: <
                 strict extends boolean = true,
@@ -312,11 +320,12 @@ export class MultiStepFormStepSchema<
           },
           subscribe: this.subscribe,
           getValue: (name) => this.getValue(step as never, name as never),
-          selectorCtx: this.createResolvedCtx({
-            stepData,
-            ctxData,
-            logger,
-          }) as never,
+          selectorCtx: () =>
+            this.createResolvedCtx({
+              stepData,
+              ctxData,
+              logger,
+            }) as never,
         });
 
         // Create useSelector hook for reactive value access via selector

--- a/packages/react/test/field.test.tsx
+++ b/packages/react/test/field.test.tsx
@@ -1,0 +1,179 @@
+import type { ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMultiStepFormSchema } from '../src';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+afterEach(async () => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
+});
+
+async function renderInJsdom(ui: ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  mountedRoots.push({ container, root });
+
+  await act(async () => {
+    root.render(ui);
+  });
+
+  return {
+    getByTestId(testId: string) {
+      const element = container.querySelector<HTMLElement>(
+        `[data-testid="${testId}"]`,
+      );
+
+      if (!element) {
+        throw new Error(`Unable to find element by test id: ${testId}`);
+      }
+
+      return element;
+    },
+  };
+}
+
+describe('Field', () => {
+  it('renders each children property to the dom', async () => {
+    const date = new Date('2024-01-01T00:00:00.000Z');
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          nameTransformCasing: 'kebab',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+              label: 'Your first name',
+            },
+            middleName: {
+              defaultValue: 'Alison',
+              label: false,
+            },
+            birthday: {
+              defaultValue: date,
+              type: 'date',
+            },
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }) => (
+      <>
+        <Field name='firstName'>
+          {({
+            defaultValue,
+            label,
+            name,
+            nameTransformCasing,
+            onInputChange,
+            reset,
+          }) => (
+            <div>
+              <p data-testid='name'>{name}</p>
+              <p data-testid='defaultValue'>{defaultValue}</p>
+              <p data-testid='label'>{label}</p>
+              <p data-testid='nameTransformCasing'>
+                {String(nameTransformCasing)}
+              </p>
+              <button data-testid='update' onClick={() => onInputChange('Jo')}>
+                update
+              </button>
+              <button data-testid='reset' onClick={() => reset()}>
+                reset
+              </button>
+            </div>
+          )}
+        </Field>
+
+        <Field
+          name='firstName'
+          selectorFn={(ctx) => ctx.step1.fields.firstName.defaultValue.length}
+        >
+          {({ selected }) => (
+            <p data-testid='selectedValue'>{selected.value}</p>
+          )}
+        </Field>
+
+        <Field name='birthday'>
+          {({ defaultValue, label, name, nameTransformCasing, type }) => (
+            <div>
+              <p data-testid='dateName'>{name}</p>
+              <p data-testid='dateDefaultValue'>{defaultValue.toISOString()}</p>
+              <p data-testid='dateLabel'>{label}</p>
+              <p data-testid='dateNameTransformCasing'>{nameTransformCasing}</p>
+              <p data-testid='dateType'>{type}</p>
+            </div>
+          )}
+        </Field>
+
+        <Field name='middleName'>
+          {(props) => (
+            <p data-testid='disabledLabelHasProp'>{String('label' in props)}</p>
+          )}
+        </Field>
+      </>
+    ));
+
+    schema.stepSchema.value.step1.createComponent(({ Field }) => (
+      <Field name='middleName'>
+        {(props) => {
+          // @ts-expect-error Disabled labels should not be exposed as a prop.
+          props.label;
+
+          return null;
+        }}
+      </Field>
+    ));
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('name').textContent).toBe('firstName');
+    expect(screen.getByTestId('defaultValue').textContent).toBe('Taylor');
+    expect(screen.getByTestId('label').textContent).toBe('Your first name');
+    expect(screen.getByTestId('nameTransformCasing').textContent).toBe('kebab');
+    expect(screen.getByTestId('selectedValue').textContent).toBe('6');
+    expect(screen.getByTestId('dateName').textContent).toBe('birthday');
+    expect(screen.getByTestId('dateLabel').textContent).toBe('birthday');
+    expect(screen.getByTestId('dateNameTransformCasing').textContent).toBe(
+      'kebab',
+    );
+    expect(screen.getByTestId('dateType').textContent).toBe('date');
+    expect(screen.getByTestId('dateDefaultValue').textContent).toBe(date.toISOString());
+    expect(screen.getByTestId('disabledLabelHasProp').textContent).toBe(
+      'false',
+    );
+
+    await act(async () => {
+      screen.getByTestId('update').click();
+    });
+
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+      'Jo',
+    );
+    expect(screen.getByTestId('defaultValue').textContent).toBe('Jo');
+    expect(screen.getByTestId('selectedValue').textContent).toBe('2');
+
+    await act(async () => {
+      screen.getByTestId('reset').click();
+    });
+
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+      'Taylor',
+    );
+    expect(screen.getByTestId('defaultValue').textContent).toBe('Taylor');
+  });
+});


### PR DESCRIPTION
## Summary

- omit disabled `label` props from resolved core field configs and React `Field` children props
- fix React `Field` metadata lookup so `label`, `nameTransformCasing`, and `type` come from the parent field config at runtime
- refresh selector context reactively so `selected.value` updates after field changes
- add core and React tests that render the relevant field props through actual runtime paths

## Root Cause

React `Field` props were reading metadata from the resolved `.defaultValue` leaf path instead of the parent field config, which caused values like `label` to be `undefined` at runtime even when the type system suggested otherwise. The selector path also captured a stale context object, so `selected.value` could stop updating after writes. Separately, disabled labels were still modeled as an exposed prop instead of being omitted.

## Impact

- `label: false` now means the `label` prop is unavailable instead of being exposed as `false` or `undefined`
- `Field` render props now match runtime behavior more closely for both metadata and selector updates
- package release notes are included via changeset for both core and react packages

## Validation

- `pnpm test:packages` passed in the original workspace before branch replacement
- package test/build pipeline passed during the original commit hook before branch replacement
- the clean replacement branch contains only the single scoped fix commit from `main`

Note: the temporary clean worktree used to recreate this branch from `origin/main` did not have `node_modules`, so `pnpm test:packages` was not rerun there after cherry-picking the already-validated commit.