### PR TITLE
fix(core): correct step-schema as return types

### DIFF
--- a/.changeset/odd-emus-invent.md
+++ b/.changeset/odd-emus-invent.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+---
+
+fix: correct step-schema `as` return types

--- a/.changeset/silver-cycles-help.md
+++ b/.changeset/silver-cycles-help.md
@@ -1,0 +1,7 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: restore `Form` inference in step component callback types
+
+Restores the custom `Form` component typing for `step.createComponent(...)` callbacks when using `withForm({ render })`, and also restores the exported `CreateStepSpecificComponentCallback` helper type so it carries the same inferred `Form` props.

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -69,13 +69,19 @@ export type AsTypeMap<
   >;
   'string.keys': Exclude<
     Join<
-      Constrain<UnionToTuple<`${ExtractStepFromKey<stepNumbers>}`>, string[]>,
+      Constrain<
+        Quote<Constrain<UnionToTuple<`${stepNumbers}`>, string[]>>,
+        string[]
+      >,
       ' | '
     >,
     ''
   >;
   number: Exclude<
-    Join<Constrain<UnionToTuple<`${stepNumbers}`>, string[]>, ' | '>,
+    Join<
+      Constrain<UnionToTuple<`${ExtractStepFromKey<stepNumbers>}`>, string[]>,
+      ' | '
+    >,
     ''
   >;
   'array.number': UnionToTuple<ExtractStepFromKey<stepNumbers>>;

--- a/packages/core/test/step-schema/as-type-transformations.test.ts
+++ b/packages/core/test/step-schema/as-type-transformations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { createMultiStepFormSchema } from '../../src';
 
 describe('multi step form step schema: as type transformations', () => {
@@ -25,30 +25,37 @@ describe('multi step form step schema: as type transformations', () => {
   const { as } = schema.stepSchema.steps;
 
   it('should transform the step numbers into a string union', () => {
+    expectTypeOf(as('string')).toEqualTypeOf<"'1' | '2'">();
     expect(as('string')).toBe("'1' | '2'");
   });
 
   it('should transform the step numbers into a string union with keys', () => {
+    expectTypeOf(as('string.keys')).toEqualTypeOf<"'step1' | 'step2'">();
     expect(as('string.keys')).toBe("'step1' | 'step2'");
   });
 
   it('should transform the step numbers into a number union', () => {
+    expectTypeOf(as('number')).toEqualTypeOf<'1 | 2'>();
     expect(as('number')).toBe('1 | 2');
   });
 
   it('should transform the step numbers into a array of numbers', () => {
+    expectTypeOf(as('array.number')).toEqualTypeOf<[1, 2]>();
     expect(as('array.number')).toStrictEqual([1, 2]);
   });
 
   it('should transform the step numbers into a array of strings', () => {
+    expectTypeOf(as('array.string')).toEqualTypeOf<['1', '2']>();
     expect(as('array.string')).toStrictEqual(['1', '2']);
   });
 
   it('should transform the step numbers into a array of strings with keys', () => {
+    expectTypeOf(as('array.string.keys')).toEqualTypeOf<['step1', 'step2']>();
     expect(as('array.string.keys')).toStrictEqual(['step1', 'step2']);
   });
 
   it('should transform the step numbers into a array of strings with untyped', () => {
+    expectTypeOf(as('array.string.untyped')).toEqualTypeOf<string[]>();
     expect(as('array.string.untyped')).toStrictEqual(['1', '2']);
   });
 });


### PR DESCRIPTION
## Summary
- correct the `AsTypeMap` typings for `steps.as('string.keys')` and `steps.as('number')`
- add compile-time `expectTypeOf(...)` assertions to the existing `as` transformation tests
- include a patch changeset for `@jfdevelops/multi-step-form-core`

## Root cause
The type-level mapping for `steps.as(...)` had the `string.keys` and `number` return shapes inverted, so the runtime values were correct but the inferred return types were not.

## Validation
- `pnpm --filter @jfdevelops/multi-step-form-core test -- as-type-transformations.test.ts`
- `pnpm --filter @jfdevelops/multi-step-form-core typecheck` *(fails on pre-existing unrelated errors in `packages/core/src/steps/fn-utils/*` and `packages/core/src/steps/utils.ts` on `main`)*
