### PR TITLE
feat: add step-level overrides, suspend, and useStep support

### DIFF
--- a/.changeset/react-overrides-suspend.md
+++ b/.changeset/react-overrides-suspend.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': minor
+---
+
+feat(react): add step-level overrides, suspend, and useStep support

--- a/.changeset/tiny-melons-suspend.md
+++ b/.changeset/tiny-melons-suspend.md
@@ -1,0 +1,10 @@
+---
+'@jfdevelops/multi-step-form-core': minor
+---
+
+feat(core): add step-level overrides with full type inference
+
+- Added `overrides` callback support on step definitions with strongly-typed `data` parameter (resolved step data with widened field defaults)
+- Added `StepOverrides`, `StepOverridePatch`, `StepOverrideResult`, and `StepResolvedData` public types
+- Added `StepDefaultValues` mapped type with index-signature filtering to produce accurate per-field primitive types
+- Supports both sync and async override functions

--- a/packages/core/src/internals/step-schema.ts
+++ b/packages/core/src/internals/step-schema.ts
@@ -11,6 +11,7 @@ import type { UpdateFn } from '@/steps/fn-utils/update-fn';
 import {
   instantiateSteps,
   type instantiateStepsConfig,
+  type StepConfig,
   type StepNumbers,
 } from '@/steps/steps';
 import { functionalUpdate, omit } from '@/steps/utils';
@@ -103,16 +104,17 @@ export namespace MultiStepFormStepSchemaInternal {
 }
 
 export namespace StepSchema {
-  export interface Config<
+  export type Config<
+    TSteps extends StepConfig = StepConfig,
     TCasing extends CasingType = DefaultCasing,
     TStorageKey extends string = string
-  > extends instantiateStepsConfig,
-      NameTransformCasingOptions<TCasing> {
-    /**
-     * The options for the storage module.
-     */
-    storage?: BaseStorageConfig<TStorageKey>;
-  }
+  > = instantiateStepsConfig<TSteps> &
+    NameTransformCasingOptions<TCasing> & {
+      /**
+       * The options for the storage module.
+       */
+      storage?: BaseStorageConfig<TStorageKey>;
+    };
 
   export type inferStorageKey<T> = T extends Config
     ? undefined extends T['storage']

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -7,7 +7,7 @@ import {
   type BaseStorageConfig,
 } from './storage.js';
 import { Subscribable } from './subscribable.js';
-import type { instantiateSteps } from './steps/steps.js';
+import type { instantiateSteps, StepConfig } from './steps/steps.js';
 
 export class MultiStepFormSchema<
   const def extends StepSchema.Config,
@@ -94,8 +94,7 @@ export class MultiStepFormSchema<
 }
 
 export function createMultiStepFormSchema<
-  const def extends StepSchema.Config,
-  value extends instantiateSteps<def>
->(options: def) {
-  return new MultiStepFormSchema<def, value>(options);
+  const TSteps extends StepConfig,
+>(options: StepSchema.Config<TSteps>) {
+  return new MultiStepFormSchema<StepSchema.Config<TSteps>>(options);
 }

--- a/packages/core/src/steps/fn-utils/helper-fn/utils.ts
+++ b/packages/core/src/steps/fn-utils/helper-fn/utils.ts
@@ -1,4 +1,4 @@
-import type { steps } from '@/steps/steps';
+import type { instantiateSteps, StepNumbers } from '@/steps/steps';
 import type { Constrain, Expand } from '@/utils';
 import type {
   AnyValidator,

--- a/packages/core/src/steps/fn-utils/reset-fn.ts
+++ b/packages/core/src/steps/fn-utils/reset-fn.ts
@@ -1,4 +1,4 @@
-import type { steps } from '../steps';
+import type { instantiateSteps, StepNumbers } from '../steps';
 import type { HelperFnChosenSteps } from './helper-fn';
 import type { UpdateFn } from './update-fn';
 

--- a/packages/core/src/steps/fn-utils/update-fn.ts
+++ b/packages/core/src/steps/fn-utils/update-fn.ts
@@ -10,7 +10,6 @@ import type {
 } from '@/utils/types';
 import type { AnySteps, instantiateSteps, StepNumbers } from '../steps';
 import type { HelperFn, HelperFnChosenSteps } from './helper-fn';
-import { CreateValidStep, ValidStepKey } from '../utils';
 
 export namespace UpdateFn {
   export type chosenFields<TCurrentStep extends AnySteps> =

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -13,6 +13,7 @@ import { addToTuple, mapToTuple } from '@/utils/helpers';
 import { createInvariant, invariant, type Invariant } from '@/utils/invariant';
 import { Subscribable } from '../subscribable';
 import {
+  getDefaultValues,
   resolvedDeepPath,
   type getFieldForStep,
   type getDeepFields,
@@ -28,8 +29,10 @@ import type {
 import type { ResetFn } from './fn-utils/reset-fn';
 import type { UpdateFn } from './fn-utils/update-fn';
 import {
+  type AnyConfig,
   instantiateSteps,
   isValidSteps,
+  type StepResolvedData,
   type StepConfig,
   type StepNumbers,
 } from './steps';
@@ -42,6 +45,13 @@ export interface MultiStepFormStepSchemaFunctions<
   reset: ResetFn.general<value>;
   createHelperFn: GeneralHelperFn<value>;
 }
+export type OverrideStatus = 'idle' | 'loading' | 'resolved' | 'error';
+
+type StepOverrideResolutionState = {
+  status: OverrideStatus;
+  error?: unknown;
+  promise?: Promise<void>;
+};
 export type AsType = (typeof AS_TYPES)[number];
 type Quote<T extends string[]> = {
   [K in keyof T]: T[K] extends string ? `'${T[K]}'` : never;
@@ -263,21 +273,6 @@ function includesValue(
   return values.some((item) => item === value);
 }
 
-function parseScalarExpression(expression: string) {
-  const parts = expression.split(' | ').map((value) => value.trim());
-  const isQuoted = parts.every(
-    (value) => value.startsWith("'") && value.endsWith("'"),
-  );
-  const parsedValues = isQuoted
-    ? parts.map((value) => value.slice(1, -1))
-    : parts.map((value) => Number(value));
-
-  return {
-    expression,
-    parsedValues,
-  };
-}
-
 function createScalarParseError(
   expression: string,
   validValues: ReadonlyArray<string | number>,
@@ -350,7 +345,7 @@ function createAsArrayValue<
     parse: Object.assign(
       (value: unknown): values => {
         if (isMatchingArray(value, validValues)) {
-          return [...values] as values;
+          return [...values] as unknown as values;
         }
 
         throw createArrayParseError(validValues, value);
@@ -430,6 +425,14 @@ export class MultiStepFormStepSchema<
   readonly steps: MultiStepFormStepStepsConfig<def, value>;
   readonly defaultNameTransformationCasing: def['nameTransformCasing'];
   readonly #stepNumbers: Array<number>;
+  readonly #baseDefaultValues = new Map<
+    StepNumbers<value>,
+    Record<string, unknown>
+  >();
+  readonly #overrideState = new Map<
+    StepNumbers<value>,
+    StepOverrideResolutionState
+  >();
   readonly #storage: MultiStepFormStorage<
     value,
     StepSchema.inferStorageKey<def>
@@ -465,6 +468,12 @@ export class MultiStepFormStepSchema<
     this.#stepNumbers = Object.keys(this.value).map((key) =>
       Number.parseInt(key.replace('step', '')),
     );
+    for (const stepKey of Object.keys(this.value) as StepNumbers<value>[]) {
+      this.#baseDefaultValues.set(
+        stepKey,
+        getDefaultValues(this.value, stepKey) as Record<string, unknown>,
+      );
+    }
 
     this.steps = {
       value: this.#stepNumbers as unknown as ReadonlyArray<StepNumbers<value>>,
@@ -524,6 +533,110 @@ export class MultiStepFormStepSchema<
     };
 
     this.sync();
+    this.initializeOverrideState();
+  }
+
+  private initializeOverrideState() {
+    for (const stepKey of Object.keys(this.value) as StepNumbers<value>[]) {
+      this.#overrideState.set(stepKey, {
+        status:
+          this.hasOverrides(stepKey) && this.isStepUsingBaseDefaults(stepKey)
+            ? 'idle'
+            : 'resolved',
+      });
+    }
+  }
+
+  private getOverrideState<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    return (
+      this.#overrideState.get(step) ?? {
+        status: 'resolved' as const,
+      }
+    );
+  }
+
+  private setOverrideState<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+    state: StepOverrideResolutionState,
+  ) {
+    this.#overrideState.set(step, state);
+    this.notify();
+  }
+
+  private isStepUsingBaseDefaults<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    const currentDefaults = getDefaultValues(this.value, step);
+    const baseDefaults = this.#baseDefaultValues.get(step);
+
+    return JSON.stringify(currentDefaults) === JSON.stringify(baseDefaults);
+  }
+
+  private getStepOverride<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    const current = this.original[step as keyof def['steps']];
+
+    if (!current || typeof current !== 'object') {
+      return undefined;
+    }
+
+    return 'overrides' in current && typeof current.overrides === 'function'
+      ? current.overrides
+      : undefined;
+  }
+
+  private getResolvedStepData<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    const currentStep = this.value[step] as value[targetStep] & {
+      update?: unknown;
+      reset?: unknown;
+      createHelperFn?: unknown;
+    };
+    const { update, reset, createHelperFn, ...resolvedStep } = currentStep;
+
+    return resolvedStep as unknown as def['steps'][Extract<
+      targetStep,
+      keyof def['steps']
+    >] extends infer TStep
+      ? TStep extends AnyConfig
+        ? StepResolvedData<TStep>
+        : never
+      : never;
+  }
+
+  private applyStepOverrides<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+    overrides: Partial<Record<string, unknown>>,
+  ) {
+    const currentStep = this.value[step] as value[targetStep] & {
+      fields: Record<string, Record<string, unknown>>;
+    };
+    const fields = currentStep.fields;
+    const nextFields = { ...fields };
+
+    for (const [fieldName, fieldValue] of Object.entries(overrides)) {
+      invariant(
+        fieldName in nextFields,
+        `[resolveStep]: "${fieldName}" is not a valid field for ${step}`,
+      );
+
+      nextFields[fieldName] = {
+        ...nextFields[fieldName],
+        defaultValue: fieldValue,
+      };
+    }
+
+    return {
+      ...this.value,
+      [step]: {
+        ...currentStep,
+        fields: nextFields,
+      },
+    } as value;
   }
 
   /**
@@ -549,6 +662,100 @@ export class MultiStepFormStepSchema<
 
       this.value = { ...enrichedValues };
     }
+  }
+
+  hasOverrides<targetStep extends StepNumbers<value>>(step: targetStep) {
+    return typeof this.getStepOverride(step) === 'function';
+  }
+
+  getStepStatus<targetStep extends StepNumbers<value>>(step: targetStep) {
+    return this.getOverrideState(step).status;
+  }
+
+  getStepError<targetStep extends StepNumbers<value>>(step: targetStep) {
+    return this.getOverrideState(step).error;
+  }
+
+  async resolveStep<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    if (!this.hasOverrides(step)) {
+      return this.value[step];
+    }
+
+    const currentState = this.getOverrideState(step);
+
+    if (currentState.status === 'resolved') {
+      return this.value[step];
+    }
+
+    if (currentState.status === 'loading' && currentState.promise) {
+      await currentState.promise;
+
+      return this.value[step];
+    }
+
+    const override = this.getStepOverride(step);
+
+    invariant(
+      typeof override === 'function',
+      `[resolveStep]: "${step}" does not have a valid override resolver`,
+    );
+
+    const promise = Promise.resolve(override(this.getResolvedStepData(step)))
+      .then((overrides) => {
+        this.#overrideState.set(step, {
+          status: 'resolved',
+        });
+
+        if (Object.keys(overrides).length === 0) {
+          this.notify();
+
+          return;
+        }
+
+        this.handlePostUpdate(
+          this.applyStepOverrides(
+            step,
+            overrides as Partial<Record<string, unknown>>,
+          ),
+        );
+      })
+      .catch((error) => {
+        this.setOverrideState(step, {
+          status: 'error',
+          error,
+        });
+
+        throw error;
+      });
+
+    this.setOverrideState(step, {
+      status: 'loading',
+      promise,
+    });
+
+    await promise;
+
+    return this.value[step];
+  }
+
+  suspendStep<targetStep extends StepNumbers<value>>(step: targetStep) {
+    if (!this.hasOverrides(step)) {
+      return this.value[step];
+    }
+
+    const state = this.getOverrideState(step);
+
+    if (state.status === 'resolved') {
+      return this.value[step];
+    }
+
+    if (state.status === 'error') {
+      throw state.error;
+    }
+
+    throw this.resolveStep(step);
   }
 
   protected notify() {

--- a/packages/core/src/steps/steps.ts
+++ b/packages/core/src/steps/steps.ts
@@ -1,3 +1,4 @@
+import { StepSchema } from '@/internals';
 import {
   CASING_TYPES,
   CasingType,
@@ -11,6 +12,7 @@ import {
 import { createInvariant, type Invariant } from '@/utils/invariant';
 import type { AnyValidator, DefaultValidator } from '@/utils/validator';
 import {
+  inferDefaultValue,
   instantiateFields,
   isValidFieldConfig,
   type FieldConfig,
@@ -20,33 +22,70 @@ import {
 import type { StepSpecificHelperFn } from './fn-utils/helper-fn/utils';
 import type { ResetFn } from './fn-utils/reset-fn';
 import type { UpdateFn } from './fn-utils/update-fn';
-import { StepSchema } from '@/internals';
-import { CreateValidStep } from './utils';
 
 export const VALIDATED_STEP_REGEX = /^step\d+$/i;
 
 type ValidStepKey<N extends number = number> = `step${N}`;
 
-export interface Config<
-  TCasing extends CasingType,
-  TFields extends FieldConfig<TCasing>,
-  TValidator = unknown
+interface BaseConfig<
+  TFields extends FieldConfig<CasingType>,
+  TCasing extends CasingType = DefaultCasing,
+  TValidator = unknown,
 > extends NameTransformCasingOptions<TCasing> {
   title: string;
   description?: string;
   fields: TFields;
   validateFields?: Constrain<TValidator, AnyValidator, DefaultValidator>;
 }
-export type AnyConfig = Config<
-  CasingType,
+export type AnyConfig = BaseConfig<
   FieldConfig<CasingType>,
+  CasingType,
   AnyValidator
 >;
+export type StepResolvedData<TConfig extends AnyConfig> = Expand<
+  {
+    title: string;
+    nameTransformCasing: inferNameTransformCasing<TConfig, DefaultCasing>;
+    fields: instantiateFields<
+      TConfig,
+      inferNameTransformCasing<TConfig, DefaultCasing>
+    >;
+  } & (TConfig extends {
+    description: infer description extends string;
+  }
+    ? { description: description }
+    : {})
+>;
+export type StepOverridePatch<TConfig extends AnyConfig> = Partial<
+  StepDefaultValues<TConfig['fields']>
+>;
+export type StepOverrideResult<TConfig extends AnyConfig> =
+  | StepOverridePatch<TConfig>
+  | Promise<StepOverridePatch<TConfig>>;
+export type StepOverrides<TConfig extends AnyConfig> = (
+  data: StepResolvedData<TConfig>,
+) => StepOverrideResult<TConfig>;
+export interface Config<
+  TFields extends FieldConfig<CasingType> = FieldConfig<CasingType>,
+  TCasing extends CasingType = DefaultCasing,
+  TValidator = unknown,
+> extends BaseConfig<TFields, TCasing, TValidator> {}
+
 export type StepConfig<
   TCasing extends CasingType = DefaultCasing,
   TFields extends FieldConfig<TCasing> = FieldConfig<TCasing>,
-  TValidator = unknown
-> = Record<ValidStepKey, Config<TCasing, TFields, TValidator>>;
+  TValidator = unknown,
+> = Record<ValidStepKey, Config<TFields, TCasing, TValidator>>;
+
+export type StepDefaultValues<TFields extends FieldConfig<CasingType>> = {
+  [key in keyof TFields as string extends key ? never : key]: inferDefaultValue<
+    TFields[key]
+  >;
+};
+
+type JustStepConfig<T> = {
+  [K in keyof T & keyof Config]: T[K];
+};
 
 export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
   /**
@@ -74,7 +113,11 @@ export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
    * }
    * ```
    */
-  steps: TMap;
+  steps: {
+    [key in keyof TMap]: JustStepConfig<TMap[key]> & {
+      overrides?: StepOverrides<TMap[key] & AnyConfig>;
+    };
+  };
 };
 /**
  * Extended step specific properties for the step.
@@ -82,13 +125,13 @@ export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
 export interface ExtendedStepSpecificProperties<
   def extends StepSchema.Config,
   value extends _instantiateSteps<def>,
-  key extends keyof value
+  _key extends keyof value,
 > {}
 
 export interface StepExtension<
   TDef extends StepSchema.Config,
   TValue extends _instantiateSteps<TDef>,
-  TKey extends keyof TValue
+  _TKey extends keyof TValue,
 > {}
 
 export type _instantiateSteps<T = unknown> = [T] extends [object]
@@ -117,7 +160,7 @@ export type _instantiateSteps<T = unknown> = [T] extends [object]
 export type BaseStepFunctions<
   def,
   value extends _instantiateSteps<def>,
-  key extends keyof value
+  key extends keyof value,
 > = Show<
   value[key] &
     (value extends {}
@@ -137,7 +180,7 @@ export type BaseStepFunctions<
 
 export type instantiateSteps<
   t = unknown,
-  value extends _instantiateSteps<t> = _instantiateSteps<t>
+  value extends _instantiateSteps<t> = _instantiateSteps<t>,
 > = Expand<{
   [key in keyof value]: BaseStepFunctions<t, value, key>;
 }>;
@@ -145,12 +188,12 @@ export type AnySteps = instantiateSteps<instantiateStepsConfig>;
 export type StepNumbers<T> = keyof T extends string ? keyof T : never;
 export type getCurrentStep<
   value extends instantiateSteps,
-  stepNumbers extends StepNumbers<value>
+  stepNumbers extends StepNumbers<value>,
 > = value[stepNumbers];
 
 export function instantiateSteps<
   const def extends instantiateStepsConfig,
-  inst = instantiateSteps<def>
+  inst = instantiateSteps<def>,
 >(def: def) {
   const { steps } = def;
   const invariant: Invariant = createInvariant('[instantiateSteps]');
@@ -160,24 +203,24 @@ export function instantiateSteps<
   invariant(
     Object.keys(steps).length > 0,
     '"steps" must contain at least one step.',
-    TypeError
+    TypeError,
   );
 
   let resolvedSteps: Record<string, unknown> = {};
 
   for (const [stepKey, stepValue] of Object.entries(steps)) {
     const invariant: Invariant = createInvariant(
-      `[instantiateSteps - ${stepKey}]`
+      `[instantiateSteps - ${stepKey}]`,
     );
 
     invariant(
       typeof stepKey === 'string',
       `Each key for the step config must be a string. Key "${stepKey}" was ${typeof stepKey} `,
-      TypeError
+      TypeError,
     );
     invariant(
       VALIDATED_STEP_REGEX.test(stepKey),
-      `The key "${stepKey}" isn't formatted properly. Each key in the step config must be the following format: "step{number}"`
+      `The key "${stepKey}" isn't formatted properly. Each key in the step config must be the following format: "step{number}"`,
     );
 
     const {
@@ -193,14 +236,14 @@ export function instantiateSteps<
     invariant(
       typeof title === 'string',
       'The title must be a string.',
-      TypeError
+      TypeError,
     );
 
     if (description) {
       invariant(
         typeof description === 'string',
         'The description must be a string.',
-        TypeError
+        TypeError,
       );
     }
 
@@ -208,15 +251,15 @@ export function instantiateSteps<
       invariant(
         typeof nameTransformCasing === 'string',
         `The nameTransformCasing must be a string. Was ${typeof nameTransformCasing}`,
-        TypeError
+        TypeError,
       );
       invariant(
         isCasingValid(nameTransformCasing),
         (formatter) =>
           `The nameTransformCasing is not a valid casing. Was ${nameTransformCasing}, must be one of ${formatter.format(
-            CASING_TYPES
+            CASING_TYPES,
           )}`,
-        TypeError
+        TypeError,
       );
     }
 

--- a/packages/core/src/steps/steps.ts
+++ b/packages/core/src/steps/steps.ts
@@ -83,9 +83,7 @@ export type StepDefaultValues<TFields extends FieldConfig<CasingType>> = {
   >;
 };
 
-type JustStepConfig<T> = {
-  [K in keyof T & keyof Config]: T[K];
-};
+type JustStepConfig<T> = Pick<T, keyof T & keyof Config>;
 
 export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
   /**

--- a/packages/core/test/step-schema/overrides.test.ts
+++ b/packages/core/test/step-schema/overrides.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { createMultiStepFormSchema } from '../../src';
+
+describe('multi step form step schema: overrides', () => {
+  it('resolves async overrides for a single step', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          overrides: async (data) => ({
+            firstName: String(data.fields.firstName.defaultValue ?? ''),
+          }),
+        },
+        step2: {
+          title: 'Step 2',
+          fields: {
+            lastName: {
+              defaultValue: '',
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('idle');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(schema.stepSchema.getValue('step1', 'firstName')).toBe('');
+
+    schema.stepSchema.update({
+      targetStep: 'step1',
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Taylor',
+    });
+
+    await schema.stepSchema.resolveStep('step1');
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getValue('step1', 'firstName')).toBe('Taylor');
+  });
+
+  it('stores override errors on the step status', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          overrides: async () => {
+            throw new Error('Failed to load');
+          },
+        },
+      },
+    });
+
+    await expect(schema.stepSchema.resolveStep('step1')).rejects.toThrow(
+      'Failed to load',
+    );
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('error');
+    expect(schema.stepSchema.getStepError('step1')).toBeInstanceOf(Error);
+  });
+});

--- a/packages/core/test/step-schema/overrides.types.test.ts
+++ b/packages/core/test/step-schema/overrides.types.test.ts
@@ -1,0 +1,129 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { createMultiStepFormSchema } from '../../src';
+
+describe('multi step form step schema: overrides types', () => {
+  it('infers override data as the resolved current step', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            age: {
+              defaultValue: 0,
+            },
+          },
+          overrides: ({ fields, title }) => {
+            expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+            expectTypeOf(fields.age.defaultValue).toEqualTypeOf<number>();
+            expectTypeOf(title).toEqualTypeOf<string>();
+
+            return { age: 890 + fields.age.defaultValue };
+          },
+        },
+      },
+    });
+  });
+
+  it('infers override data for destructured arrow functions', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            age: {
+              defaultValue: 0,
+            },
+          },
+          overrides: ({ fields }) => {
+            expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+            expectTypeOf(fields.age.defaultValue).toEqualTypeOf<number>();
+
+            return {
+              age: 42,
+            };
+          },
+        },
+      },
+    });
+  });
+
+  it('rejects override keys that are not defined on the current step', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          // @ts-expect-error invalid override key
+          overrides: () => {
+            return {
+              lastName: 'Finkel',
+            };
+          },
+        },
+      },
+    });
+  });
+
+  it('supports async overrides', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            age: {
+              defaultValue: 0,
+            },
+          },
+          overrides: async ({ fields, title }) => {
+            expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+            expectTypeOf(fields.age.defaultValue).toEqualTypeOf<number>();
+            expectTypeOf(title).toEqualTypeOf<string>();
+
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            return { age: 42 };
+          },
+        },
+      },
+    });
+  });
+
+  it('keeps the return type constrained to the current step defaults', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            age: {
+              defaultValue: 0,
+            },
+          },
+          overrides: ({ fields }) => {
+            expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+            expectTypeOf(fields.age.defaultValue).toEqualTypeOf<number>();
+
+            return {
+              firstName: 'Taylor',
+            };
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/react/src/create-context.tsx
+++ b/packages/react/src/create-context.tsx
@@ -383,7 +383,7 @@ export function createMultiStepFormContext<
       (formatter) =>
         `Invalid step number "${
           options.targetStep
-        }". Valid steps are: ${formatter.format(as('array.string.untyped'))}`
+        }". Valid steps are: ${formatter.format(as('array.string.untyped').value)}`
     );
 
     return createComponent({ targetStep: options.targetStep })(cb);

--- a/packages/react/src/field.tsx
+++ b/packages/react/src/field.tsx
@@ -11,7 +11,7 @@ import type {
   Updater
 } from '@jfdevelops/multi-step-form-core';
 import type { ReactNode } from 'react';
-import { memo, useSyncExternalStore } from 'react';
+import { Suspense, memo, useSyncExternalStore } from 'react';
 import type { SelectorFn } from './hooks/use-selector';
 import { selector } from './selector';
 
@@ -96,14 +96,24 @@ export namespace field {
     step extends instantiateSteps,
     field extends getDeepFields<step, StepNumbers<step>>,
     selected,
-  > = sharedProps<field> & {
-    selectorFn?: SelectorFn<step, selected>;
-    children: (
-      props: [selected] extends [never]
-        ? childrenProps<step, field>
-        : childrenPropsWithSelected<step, field, selected>
-    ) => ReactNode;
-  };
+  > = sharedProps<field> &
+    (
+      | {
+          suspend?: false;
+          fallback?: never;
+        }
+      | {
+          suspend: true;
+          fallback: ReactNode;
+        }
+    ) & {
+      selectorFn?: SelectorFn<step, selected>;
+      children: (
+        props: [selected] extends [never]
+          ? childrenProps<step, field>
+          : childrenPropsWithSelected<step, field, selected>
+      ) => ReactNode;
+    };
   export type component<steps extends instantiateSteps> = <
     field extends getDeepFields<steps, StepNumbers<steps>>,
     selected = never,
@@ -124,6 +134,7 @@ export namespace field {
       name: field
     ) => resolveDeepFieldPath<step, StepNumbers<step>, field>;
     selectorCtx: () => Expand<HelperFn.buildCtx<step, [StepNumbers<step>]>>;
+    suspendStep?: () => void;
   };
 
   /**
@@ -136,7 +147,7 @@ export namespace field {
   export function create<step extends instantiateSteps>(
     options: createOptions<step>
   ) {
-    const { propsCreator, subscribe, getValue, selectorCtx } = options;
+    const { propsCreator, subscribe, getValue, selectorCtx, suspendStep } = options;
 
     const Field: field.component<step> = (props) => {
       const { name, children, selectorFn } = props;
@@ -162,22 +173,40 @@ export namespace field {
         } as never;
       }
 
-      if (selectorFn) {
-        const Selector = selector.create<step>(selectorCtx, subscribeFn);
+      const renderChildren = () => {
+        if (selectorFn) {
+          const Selector = selector.create<step>(selectorCtx, subscribeFn);
+
+          return (
+            <Selector selector={selectorFn}>
+              {(value) =>
+                children({
+                  ...createdProps,
+                  selected: { value: value as never },
+                } as never)
+              }
+            </Selector>
+          );
+        }
+
+        return children(createdProps as never);
+      };
+
+      if (props.suspend) {
+        function FieldResolutionGate() {
+          suspendStep?.();
+
+          return renderChildren();
+        }
 
         return (
-          <Selector selector={selectorFn}>
-            {(value) =>
-              children({
-                ...createdProps,
-                selected: { value: value as never },
-              } as never)
-            }
-          </Selector>
+          <Suspense fallback={props.fallback}>
+            <FieldResolutionGate />
+          </Suspense>
         );
       }
 
-      return children(createdProps as never);
+      return renderChildren();
     };
 
     return memo(Field);

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -218,9 +218,8 @@ export class MultiStepFormSchema<
   }
 }
 
-export function createMultiStepFormSchema<
-  const def extends StepSchema.Config,
-  value extends instantiateReactSteps<def> = instantiateReactSteps<def>
->(options: def) {
-  return new MultiStepFormSchema<def, value>(options);
+export function createMultiStepFormSchema<const def extends StepSchema.Config>(
+  options: def
+) {
+  return new MultiStepFormSchema<def>(options);
 }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -34,6 +34,13 @@ import {
   getValidatedCustomInputHooks,
   resolvedCtxCreator,
 } from './utils';
+import {
+  Suspense,
+  createElement,
+  useEffect,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
 
 export type CreateComponentFn<
   def extends StepSchema.Config,
@@ -158,6 +165,58 @@ export class MultiStepFormStepSchema<
     }
 
     return ctx;
+  }
+
+  private createUseStep<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    return () => {
+      const status = useSyncExternalStore(
+        this.subscribe,
+        () => this.getStepStatus(step as never),
+        () => this.getStepStatus(step as never),
+      );
+      const data = useSyncExternalStore(
+        this.subscribe,
+        () => this.value[step],
+        () => this.value[step],
+      );
+      const error = useSyncExternalStore(
+        this.subscribe,
+        () => this.getStepError(step as never),
+        () => this.getStepError(step as never),
+      );
+
+      useEffect(() => {
+        void this.resolveStep(step as never);
+      }, []);
+
+      return {
+        data,
+        status,
+        error,
+      };
+    };
+  }
+
+  private createStepSuspend<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    return (props: { children: ReactNode; fallback: ReactNode }) => {
+      const { children, fallback } = props;
+
+      const StepResolutionGate = () => {
+        this.suspendStep(step as never);
+
+        return children;
+      };
+
+      return createElement(
+        Suspense,
+        { fallback },
+        createElement(StepResolutionGate),
+      );
+    };
   }
 
   private createStepSpecificComponentImpl<
@@ -326,6 +385,9 @@ export class MultiStepFormStepSchema<
               ctxData,
               logger,
             }) as never,
+          suspendStep: () => {
+            this.suspendStep(step as never);
+          },
         });
 
         // Create useSelector hook for reactive value access via selector
@@ -343,12 +405,16 @@ export class MultiStepFormStepSchema<
           () => this.createResolvedCtx({ stepData, ctxData, logger }) as never,
           this.subscribe
         );
+        const useStep = this.createUseStep(step);
+        const SuspendStep = this.createStepSuspend(step);
 
         let fnInput = {
           ctx: resolvedCtx,
           onInputChange: this.#internal.createStepUpdaterFn(step),
           reset: this.#internal.createStepResetterFn(step),
           Field,
+          Suspend: SuspendStep,
+          useStep,
           useSelector,
           Selector,
           defaultValues: this.createDefaultValues(step as never) as never,

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -6,12 +6,13 @@ import type {
   HelperFn,
   HelperFnChosenSteps,
   HelperFnInput,
+  OverrideStatus,
   ResetFn,
   StepNumbers,
   UpdateFn,
 } from '@jfdevelops/multi-step-form-core';
 import { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
-import type { ComponentPropsWithRef } from 'react';
+import type { ComponentPropsWithRef, ReactNode } from 'react';
 import { field } from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { UseSelector } from './hooks/use-selector';
@@ -105,6 +106,28 @@ export namespace StepSpecificComponent {
   > = Expand<{
     [key in targetStep]: HelperFnChosenSteps.currentStep<value, [key]>;
   }>;
+  export type useStepResult<
+    value extends instantiateReactSteps,
+    targetStep extends StepNumbers<value>,
+  > = {
+    data: HelperFnChosenSteps.currentStep<value, [targetStep]>;
+    status: OverrideStatus;
+    error: unknown;
+  };
+  export type useStep<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+  > = () => useStepResult<value, targetStep>;
+  export type suspendProps = {
+    children: ReactNode;
+    fallback: ReactNode;
+  };
+  export type suspendComponent<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    _targetStep extends StepNumbers<value>,
+  > = (props: suspendProps) => ReactNode;
 
   export type input<
     def extends StepSchema.Config,
@@ -140,6 +163,14 @@ export namespace StepSpecificComponent {
        * </Selector>
        */
       Selector: selector.component<buildCurrentStep<def, value, targetStep>>;
+      /**
+       * Reactively resolves the current step overrides and exposes the current resolution status.
+       */
+      useStep: useStep<def, value, targetStep>;
+      /**
+       * Suspends the current step until async overrides have been resolved.
+       */
+      Suspend: suspendComponent<def, value, targetStep>;
       /**
        * An object containing the default values for every field in the current step,
        * as defined in the schema config.

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -568,6 +568,41 @@ describe('creating components via "createComponent" fn', () => {
       it.todo(
         'does not inject Form when the step is excluded by enabledForSteps',
       );
+
+      it('infers step suspense helpers from the step field defaults', () => {
+        const schema = createMultiStepFormSchema({
+          steps: {
+            step1: {
+              title: 'Step 1',
+              fields: {
+                firstName: {
+                  defaultValue: '',
+                },
+              },
+              overrides: (data) => ({
+                firstName: data.fields.firstName.defaultValue,
+              }),
+            },
+          },
+        });
+
+        schema.stepSchema.value.step1.createComponent(
+          ({ useStep, Suspend, Field }) => {
+            const { data, status } = useStep();
+
+            status satisfies 'idle' | 'loading' | 'resolved' | 'error';
+            data.fields.firstName.defaultValue satisfies string;
+
+            return (
+              <Suspend fallback={null}>
+                <Field name='firstName'>
+                  {({ defaultValue }) => defaultValue}
+                </Field>
+              </Suspend>
+            );
+          },
+        );
+      });
     });
   });
 });

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -73,7 +73,7 @@ describe('step overrides', () => {
               defaultValue: '',
             },
           },
-          
+          overrides: () => deferred.promise,
         },
       },
     });

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -1,0 +1,199 @@
+import type { ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMultiStepFormSchema } from '../../src';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+afterEach(async () => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
+  window.localStorage.clear();
+});
+
+async function renderInJsdom(ui: ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  mountedRoots.push({ container, root });
+
+  await act(async () => {
+    root.render(ui);
+  });
+
+  return {
+    getByTestId(testId: string) {
+      const element = container.querySelector<HTMLElement>(
+        `[data-testid="${testId}"]`,
+      );
+
+      if (!element) {
+        throw new Error(`Unable to find element by test id: ${testId}`);
+      }
+
+      return element;
+    },
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
+
+describe('step overrides', () => {
+  it('suspends the full step through Suspend', async () => {
+    const deferred = createDeferred<{ firstName: string }>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(
+      ({ Field, Suspend }) => (
+        <Suspend fallback={<p data-testid='loading'>Loading</p>}>
+          <Field name='firstName'>
+            {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
+          </Field>
+        </Suspend>
+      ),
+    );
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('loading').textContent).toBe('Loading');
+
+    await act(async () => {
+      deferred.resolve({
+        firstName: 'Taylor',
+      });
+    });
+
+    expect(screen.getByTestId('value').textContent).toBe('Taylor');
+  });
+
+  it('supports field-level suspension', async () => {
+    const deferred = createDeferred<{ firstName: string }>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          overrides: async () => {
+            const values = await deferred.promise;
+
+            return {
+              firstName: values.firstName,
+            };
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(
+      ({ Field }) => (
+        <Field
+          name='firstName'
+          suspend
+          fallback={<p data-testid='field-loading'>Loading field</p>}
+        >
+          {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
+        </Field>
+      ),
+    );
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('loading');
+
+    await act(async () => {
+      deferred.resolve({
+        firstName: 'Jordan',
+      });
+    });
+
+    expect(screen.getByTestId('value').textContent).toBe('Jordan');
+  });
+
+  it('exposes the current override status through useStep', async () => {
+    const deferred = createDeferred<{ firstName: string }>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          overrides: async () => {
+            const values = await deferred.promise;
+
+            return {
+              firstName: values.firstName,
+            };
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(
+      ({ useStep }) => {
+        const { data, status } = useStep();
+
+        return (
+          <>
+            <p data-testid='status'>{status}</p>
+            <p data-testid='value'>{data.fields.firstName.defaultValue}</p>
+          </>
+        );
+      },
+    );
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('value').textContent).toBe('');
+
+    await act(async () => {
+      deferred.resolve({
+        firstName: 'Jordan',
+      });
+    });
+
+    expect(screen.getByTestId('status').textContent).toBe('resolved');
+    expect(screen.getByTestId('value').textContent).toBe('Jordan');
+  });
+});


### PR DESCRIPTION
## Summary

- **core**: Add `overrides` callback on step definitions with strongly-typed `data` parameter (specific field names, widened primitive types). Supports both sync and async overrides. Exports `StepOverrides`, `StepOverridePatch`, `StepOverrideResult`, `StepResolvedData`, and `StepDefaultValues` types.
- **core**: Fix `JustStepConfig` to use `Pick<T, keyof T & keyof Config>` (homomorphic, preserves optional modifiers) instead of the non-homomorphic form that made optional step properties required during constraint checking.
- **react**: Add `Suspend` component and `useStep` hook to step `createComponent` callbacks, enabling step-level and field-level suspension during async override resolution. Add `getStepStatus`, `getStepError`, `resolveStep`, and `suspendStep` methods to the step schema.

## Test plan

- [x] `pnpm --filter "@jfdevelops/multi-step-form-core" test` — all core tests pass
- [x] `pnpm --filter "@jfdevelops/react-multi-step-form" test` — all 17 react tests pass
- [x] `pnpm --filter "@jfdevelops/react-multi-step-form" exec tsc --noEmit` — zero TypeScript errors