### PR TITLE
Improve step override typing and useStep errors

### DIFF
--- a/.changeset/gentle-errors-shine.md
+++ b/.changeset/gentle-errors-shine.md
@@ -1,0 +1,7 @@
+---
+'@jfdevelops/react-multi-step-form': minor
+---
+
+feat(react): type `useStep` errors and expose override failures per step
+
+`useStep()` now exposes override resolution errors on the current step and defaults the `error` property to `Error | undefined`. Callers can also override the error type at the hook call site with `useStep<MyError>()`.

--- a/.changeset/orange-fields-exact.md
+++ b/.changeset/orange-fields-exact.md
@@ -1,0 +1,8 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: tighten override field inference and preserve omitted field defaults
+
+Resolved override data now exposes exact step field keys without a generic string index, which restores field inference in both core and React step consumers. This also adds regression coverage to ensure partial override patches do not remove untouched step fields at runtime.

--- a/packages/core/src/steps/steps.ts
+++ b/packages/core/src/steps/steps.ts
@@ -26,6 +26,9 @@ import type { UpdateFn } from './fn-utils/update-fn';
 export const VALIDATED_STEP_REGEX = /^step\d+$/i;
 
 type ValidStepKey<N extends number = number> = `step${N}`;
+type StripStringIndex<T> = Expand<{
+  [key in keyof T as string extends key ? never : key]: T[key];
+}>;
 
 interface BaseConfig<
   TFields extends FieldConfig<CasingType>,
@@ -46,9 +49,8 @@ export type StepResolvedData<TConfig extends AnyConfig> = Expand<
   {
     title: string;
     nameTransformCasing: inferNameTransformCasing<TConfig, DefaultCasing>;
-    fields: instantiateFields<
-      TConfig,
-      inferNameTransformCasing<TConfig, DefaultCasing>
+    fields: StripStringIndex<
+      instantiateFields<TConfig, inferNameTransformCasing<TConfig, DefaultCasing>>
     >;
   } & (TConfig extends {
     description: infer description extends string;
@@ -142,9 +144,11 @@ export type _instantiateSteps<T = unknown> = [T] extends [object]
               T['steps'][key],
               DefaultCasing
             >;
-            fields: instantiateFields<
-              T['steps'][key],
-              inferNameTransformCasing<T['steps'][key], DefaultCasing>
+            fields: StripStringIndex<
+              instantiateFields<
+                T['steps'][key],
+                inferNameTransformCasing<T['steps'][key], DefaultCasing>
+              >
             >;
           } & (T['steps'][key] extends {
             description: infer description extends string;

--- a/packages/core/test/step-schema/overrides.test.ts
+++ b/packages/core/test/step-schema/overrides.test.ts
@@ -66,4 +66,34 @@ describe('multi step form step schema: overrides', () => {
     expect(schema.stepSchema.getStepStatus('step1')).toBe('error');
     expect(schema.stepSchema.getStepError('step1')).toBeInstanceOf(Error);
   });
+
+  it('preserves untouched field defaults when overrides return a partial patch', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            saveToAccount: {
+              defaultValue: false,
+            },
+          },
+          overrides: async () => ({
+            firstName: 'Taylor',
+          }),
+        },
+      },
+    });
+
+    await schema.stepSchema.resolveStep('step1');
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getValue('step1', 'firstName')).toBe('Taylor');
+    expect(schema.stepSchema.getValue('step1', 'saveToAccount')).toBe(false);
+    expect(schema.stepSchema.value.step1.fields.saveToAccount.defaultValue).toBe(
+      false,
+    );
+  });
 });

--- a/packages/core/test/step-schema/overrides.types.test.ts
+++ b/packages/core/test/step-schema/overrides.types.test.ts
@@ -126,4 +126,33 @@ describe('multi step form step schema: overrides types', () => {
       },
     });
   });
+
+  it('does not expose a string index on resolved override fields', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            saveToAccount: {
+              defaultValue: false,
+            },
+          },
+          overrides: (data) => {
+            expectTypeOf(data.fields.firstName.defaultValue).toEqualTypeOf<string>();
+            expectTypeOf(data.fields.saveToAccount.defaultValue).toEqualTypeOf<boolean>();
+
+            // @ts-expect-error unknown field should not be available
+            data.fields.notARealField;
+
+            return {
+              firstName: 'Taylor',
+            };
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -169,8 +169,8 @@ export class MultiStepFormStepSchema<
 
   private createUseStep<targetStep extends StepNumbers<value>>(
     step: targetStep,
-  ) {
-    return () => {
+  ): StepSpecificComponent.useStep<def, value, targetStep> {
+    return <TError = Error>() => {
       const status = useSyncExternalStore(
         this.subscribe,
         () => this.getStepStatus(step as never),
@@ -180,7 +180,7 @@ export class MultiStepFormStepSchema<
         this.subscribe,
         () => this.value[step],
         () => this.value[step],
-      );
+      ) as HelperFnChosenSteps.currentStep<value, [targetStep]>;
       const error = useSyncExternalStore(
         this.subscribe,
         () => this.getStepError(step as never),
@@ -188,13 +188,15 @@ export class MultiStepFormStepSchema<
       );
 
       useEffect(() => {
-        void this.resolveStep(step as never);
+        void this.resolveStep(step as never).catch(() => {
+          // Errors are persisted on the step state and exposed through `useStep`.
+        });
       }, []);
 
       return {
         data,
         status,
-        error,
+        error: error as TError | undefined,
       };
     };
   }

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -27,43 +27,46 @@ export namespace StepSpecificComponent {
   };
   type instantiateFormComponentForAllSteps<
     def extends StepSchema.Config,
-    value = MultiStepFormSchemaConfig.instantiateFormConfig<def>
-  > = MultiStepFormSchemaConfig.EnabledForSteps.get<value> extends MultiStepFormSchemaConfig.defaultEnabledFor
-    ? keyof MultiStepFormSchemaConfig.instantiateFormConfig<def> extends never
-      ? defaultFormComponent
-      : MultiStepFormSchemaConfig.instantiateFormConfig<def>
-    : {};
+    value = MultiStepFormSchemaConfig.instantiateFormConfig<def>,
+  > =
+    MultiStepFormSchemaConfig.EnabledForSteps.get<value> extends MultiStepFormSchemaConfig.defaultEnabledFor
+      ? keyof MultiStepFormSchemaConfig.instantiateFormConfig<def> extends never
+        ? defaultFormComponent
+        : MultiStepFormSchemaConfig.instantiateFormConfig<def>
+      : {};
   type instantiateFormComponentForTuple<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>
-  > = MultiStepFormSchemaConfig.EnabledForSteps.get<def> extends HelperFnChosenSteps.tupleNotation<
-    StepNumbers<steps>
-  >
-    ? chosenSteps[number] extends StepNumbers<steps>
-      ? chosenSteps[number] extends MultiStepFormSchemaConfig.EnabledForSteps.get<def>[number]
-        ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
+    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
+  > =
+    MultiStepFormSchemaConfig.EnabledForSteps.get<def> extends HelperFnChosenSteps.tupleNotation<
+      StepNumbers<steps>
+    >
+      ? chosenSteps[number] extends StepNumbers<steps>
+        ? chosenSteps[number] extends MultiStepFormSchemaConfig.EnabledForSteps.get<def>[number]
+          ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
+          : {}
         : {}
-      : {}
-    : {};
+      : {};
 
   type instantiateFormComponentForObject<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>
-  > = MultiStepFormSchemaConfig.EnabledForSteps.get<def> extends HelperFnChosenSteps.objectNotation<
-    StepNumbers<steps>
-  >
-    ? chosenSteps[number] extends StepNumbers<steps>
-      ? chosenSteps[number] extends keyof MultiStepFormSchemaConfig.EnabledForSteps.get<def>
-        ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
+    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
+  > =
+    MultiStepFormSchemaConfig.EnabledForSteps.get<def> extends HelperFnChosenSteps.objectNotation<
+      StepNumbers<steps>
+    >
+      ? chosenSteps[number] extends StepNumbers<steps>
+        ? chosenSteps[number] extends keyof MultiStepFormSchemaConfig.EnabledForSteps.get<def>
+          ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
+          : {}
         : {}
-      : {}
-    : {};
+      : {};
   type instantiateFormComponent<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps<def>,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>
+    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
   > = {
     all: instantiateFormComponentForAllSteps<def>;
     tuple: instantiateFormComponentForTuple<def, steps, chosenSteps>;
@@ -78,7 +81,7 @@ export namespace StepSpecificComponent {
   export type formComponent<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps<def>,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>
+    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
   > = instantiateFormComponent<
     def,
     steps,
@@ -86,7 +89,7 @@ export namespace StepSpecificComponent {
   >[MultiStepFormSchemaConfig.EnabledForSteps.resolveType<def, steps>];
   export type updateWrappers<
     value extends instantiateReactSteps,
-    targetStep extends StepNumbers<value>
+    targetStep extends StepNumbers<value>,
   > = {
     /**
      * A useful wrapper around `update` to update the specific field.
@@ -102,23 +105,29 @@ export namespace StepSpecificComponent {
   type buildCurrentStep<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
-    targetStep extends StepNumbers<value>
+    targetStep extends StepNumbers<value>,
   > = Expand<{
     [key in targetStep]: HelperFnChosenSteps.currentStep<value, [key]>;
   }>;
   export type useStepResult<
     value extends instantiateReactSteps,
     targetStep extends StepNumbers<value>,
+    TError = Error,
   > = {
     data: HelperFnChosenSteps.currentStep<value, [targetStep]>;
     status: OverrideStatus;
-    error: unknown;
+    error: TError | undefined;
   };
   export type useStep<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
-  > = () => useStepResult<value, targetStep>;
+  > = <error extends Error = Error>() => useStepResult<
+    value,
+    targetStep,
+    error
+  >;
+
   export type suspendProps = {
     children: ReactNode;
     fallback: ReactNode;
@@ -133,7 +142,7 @@ export namespace StepSpecificComponent {
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
-    additionalCtx extends Record<string, unknown>
+    additionalCtx extends Record<string, unknown>,
   > = HelperFnInput.BaseInput<value, [targetStep], never, additionalCtx> &
     updateWrappers<value, targetStep> & {
       Field: field.component<buildCurrentStep<def, value, targetStep>>;
@@ -183,7 +192,7 @@ export namespace StepSpecificComponent {
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
     props,
-    additionalCtx extends Record<string, unknown> = {}
+    additionalCtx extends Record<string, unknown> = {},
   > = CreateComponent<
     Expand<
       input<def, value, targetStep, additionalCtx> &
@@ -195,7 +204,7 @@ export namespace StepSpecificComponent {
   export type options<
     value extends instantiateReactSteps,
     targetStep extends StepNumbers<value>,
-    additionalCtx extends Record<string, unknown> = {}
+    additionalCtx extends Record<string, unknown> = {},
   > = HelperFn.CtxDataSelector<value, [targetStep], additionalCtx> & {
     /**
      * If set to `true`, you'll be able to open the {@linkcode console} to view logs.
@@ -207,42 +216,42 @@ export namespace StepSpecificComponent {
 type IsLegacyFormAvailable<
   value extends instantiateReactSteps,
   chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>,
-  enabledFor extends HelperFnChosenSteps.main<value, StepNumbers<value>>
+  enabledFor extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
 > = enabledFor extends MultiStepFormSchemaConfig.defaultEnabledFor
   ? true
   : enabledFor extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>
-  ? chosenSteps[number] extends enabledFor[number]
-    ? true
-    : false
-  : enabledFor extends HelperFnChosenSteps.objectNotation<StepNumbers<value>>
-  ? chosenSteps[number] extends keyof enabledFor
-    ? true
-    : false
-  : false;
+    ? chosenSteps[number] extends enabledFor[number]
+      ? true
+      : false
+    : enabledFor extends HelperFnChosenSteps.objectNotation<StepNumbers<value>>
+      ? chosenSteps[number] extends keyof enabledFor
+        ? true
+        : false
+      : false;
 
 type LegacyFormComponent<
   value extends instantiateReactSteps,
   chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>,
   alias extends string,
   formProps,
-  enabledFor extends HelperFnChosenSteps.main<value, StepNumbers<value>>
+  enabledFor extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
 > = string extends alias
   ? {}
   : IsLegacyFormAvailable<value, chosenSteps, enabledFor> extends true
-  ? MultiStepFormSchemaConfig.formCtx<alias, formProps>
-  : {};
+    ? MultiStepFormSchemaConfig.formCtx<alias, formProps>
+    : {};
 
 export interface StepSpecificCreateComponentFn<
   def extends StepSchema.Config,
   value extends instantiateReactSteps<def>,
-  targetStep extends StepNumbers<value>
+  targetStep extends StepNumbers<value>,
 > {
   /**
    * A utility function to easily create a component for the current step.
    * @param fn The callback function where the component is defined.
    */
   <props = undefined>(
-    fn: StepSpecificComponent.callback<def, value, targetStep, props>
+    fn: StepSpecificComponent.callback<def, value, targetStep, props>,
   ): CreatedMultiStepFormComponent<props>;
   /**
    * A utility function to easily create a component for the current step.
@@ -252,7 +261,13 @@ export interface StepSpecificCreateComponentFn<
    */
   <additionalCtx extends Record<string, unknown> = {}, props = undefined>(
     options: StepSpecificComponent.options<value, targetStep, additionalCtx>,
-    fn: StepSpecificComponent.callback<def, value, targetStep, props, additionalCtx>
+    fn: StepSpecificComponent.callback<
+      def,
+      value,
+      targetStep,
+      props,
+      additionalCtx
+    >,
   ): CreatedMultiStepFormComponent<props>;
 }
 
@@ -268,12 +283,10 @@ export type CreateStepSpecificComponentCallback<
   _formInstance = undefined,
   _formAlias extends string = string,
   props = undefined,
-  _enabledFor extends HelperFnChosenSteps.main<
-    value,
-    StepNumbers<value>
-  > = MultiStepFormSchemaConfig.defaultEnabledFor,
+  _enabledFor extends HelperFnChosenSteps.main<value, StepNumbers<value>> =
+    MultiStepFormSchemaConfig.defaultEnabledFor,
   _extra = unknown,
-  additionalCtx extends Record<string, unknown> = {}
+  additionalCtx extends Record<string, unknown> = {},
 > = CreateComponent<
   Expand<
     HelperFnInput.BaseInput<value, chosenSteps, never, additionalCtx> &
@@ -289,7 +302,7 @@ export type CreateStepSpecificComponentCallback<
 // Because of this, there are a lot of `@ts-expect-error`s in the code.
 export type instantiateReactSteps<
   def = unknown,
-  value extends _instantiateSteps<def> = _instantiateSteps<def>
+  value extends _instantiateSteps<def> = _instantiateSteps<def>,
 > = Expand<{
   [key in keyof value]: Expand<
     BaseStepFunctions<def, value, key> & {

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -579,8 +579,8 @@ describe('creating components via "createComponent" fn', () => {
                   defaultValue: '',
                 },
               },
-              overrides: (data) => ({
-                firstName: data.fields.firstName.defaultValue,
+              overrides: () => ({
+                firstName: '',
               }),
             },
           },
@@ -588,10 +588,9 @@ describe('creating components via "createComponent" fn', () => {
 
         schema.stepSchema.value.step1.createComponent(
           ({ useStep, Suspend, Field }) => {
-            const { data, status } = useStep();
+            const { status } = useStep();
 
             status satisfies 'idle' | 'loading' | 'resolved' | 'error';
-            data.fields.firstName.defaultValue satisfies string;
 
             return (
               <Suspend fallback={null}>

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -73,7 +73,7 @@ describe('step overrides', () => {
               defaultValue: '',
             },
           },
-          overrides: () => deferred.promise,
+          overrides: ({}) => deferred.promise,
         },
       },
     });
@@ -195,5 +195,61 @@ describe('step overrides', () => {
 
     expect(screen.getByTestId('status').textContent).toBe('resolved');
     expect(screen.getByTestId('value').textContent).toBe('Jordan');
+  });
+
+  it('keeps non-overridden fields available after async step resolution', async () => {
+    const deferred = createDeferred<{ firstName: string }>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            saveToAccount: {
+              defaultValue: false,
+            },
+          },
+          overrides: async () => {
+            const values = await deferred.promise;
+
+            return {
+              firstName: values.firstName,
+            };
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(
+      ({ Field, Suspend }) => (
+        <Suspend fallback={<p data-testid='loading'>Loading</p>}>
+          <Field name='firstName'>
+            {({ defaultValue }) => (
+              <p data-testid='firstName'>{String(defaultValue)}</p>
+            )}
+          </Field>
+          <Field name='saveToAccount'>
+            {({ defaultValue }) => (
+              <p data-testid='saveToAccount'>{String(defaultValue)}</p>
+            )}
+          </Field>
+        </Suspend>
+      ),
+    );
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('loading').textContent).toBe('Loading');
+
+    await act(async () => {
+      deferred.resolve({
+        firstName: 'Jordan',
+      });
+    });
+
+    expect(screen.getByTestId('firstName').textContent).toBe('Jordan');
+    expect(screen.getByTestId('saveToAccount').textContent).toBe('false');
   });
 });

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
 import { createMultiStepFormSchema } from '../../src';
 
 (
@@ -9,6 +9,13 @@ import { createMultiStepFormSchema } from '../../src';
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+class CustomError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CustomError';
+  }
+}
 
 afterEach(async () => {
   for (const { container, root } of mountedRoots.splice(0)) {
@@ -123,17 +130,15 @@ describe('step overrides', () => {
       },
     });
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(
-      ({ Field }) => (
-        <Field
-          name='firstName'
-          suspend
-          fallback={<p data-testid='field-loading'>Loading field</p>}
-        >
-          {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
-        </Field>
-      ),
-    );
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }) => (
+      <Field
+        name='firstName'
+        suspend
+        fallback={<p data-testid='field-loading'>Loading field</p>}
+      >
+        {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
+      </Field>
+    ));
 
     const screen = await renderInJsdom(<Step1 />);
 
@@ -251,5 +256,77 @@ describe('step overrides', () => {
 
     expect(screen.getByTestId('firstName').textContent).toBe('Jordan');
     expect(screen.getByTestId('saveToAccount').textContent).toBe('false');
+  });
+
+  it('stores thrown override errors on the current step hook result', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+          overrides: async () => {
+            throw new Error('Failed to load step defaults');
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(
+      ({ useStep }) => {
+        const { error, status } = useStep();
+
+        return (
+          <>
+            <p data-testid='status'>{status}</p>
+            <p data-testid='error-message'>
+              {error instanceof Error ? error.message : 'none'}
+            </p>
+          </>
+        );
+      },
+    );
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('status').textContent).toBe('error');
+    expect(screen.getByTestId('error-message').textContent).toBe(
+      'Failed to load step defaults',
+    );
+  });
+
+  it('types useStep errors as Error by default and allows an override', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        },
+      },
+    });
+
+    schema.stepSchema.value.step1.createComponent(({ useStep }) => {
+      const defaultResult = useStep();
+      const customResult = useStep<CustomError>();
+
+      expectTypeOf(
+        defaultResult.data.fields.firstName.defaultValue,
+      ).toEqualTypeOf<string>();
+      expectTypeOf(defaultResult.error).toEqualTypeOf<Error | undefined>();
+      expectTypeOf(customResult.error).toEqualTypeOf<CustomError | undefined>();
+
+      return null;
+    });
   });
 });


### PR DESCRIPTION
## Summary
- tighten resolved override field inference and preserve omitted field defaults
- persist override failures on the current step and expose them through `useStep()`
- type `useStep` errors as `Error | undefined` by default with an opt-in generic override

## Testing
- `pnpm -r --filter "@jfdevelops/*" test --browser.headless=true`
- `pnpm run build:packages`