### PR TITLE
fix(schema): align react factory override inference

### DIFF
--- a/.changeset/shiny-fields-agree.md
+++ b/.changeset/shiny-fields-agree.md
@@ -1,0 +1,8 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+'@jfdevelops/multi-step-form-core': patch
+---
+
+fix: restore override field inference in react schema factory
+
+Aligns the React schema factory with the core factory so step `overrides` callbacks receive properly inferred `fields` data. Also adds regression coverage to ensure partial override patches still preserve untouched step fields through `withForm()` and `withContext()`.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -11,7 +11,7 @@ import type { instantiateSteps, StepConfig } from './steps/steps.js';
 
 export class MultiStepFormSchema<
   const def extends StepSchema.Config,
-  value extends instantiateSteps<def> = instantiateSteps<def>
+  value extends instantiateSteps<def> = instantiateSteps<def>,
 > extends Subscribable<MultiStepFormStepSchema.Listener<def, value>> {
   readonly defaultNameTransformationCasing: def['nameTransformCasing'];
   readonly stepSchema: MultiStepFormStepSchema<def, value>;
@@ -27,7 +27,7 @@ export class MultiStepFormSchema<
     const { steps, nameTransformCasing, storage } = options;
 
     this.defaultNameTransformationCasing = setCasingType(
-      nameTransformCasing
+      nameTransformCasing,
     ) as def['nameTransformCasing'];
     this.stepSchema = new MultiStepFormStepSchema<def, value>({
       steps,
@@ -93,8 +93,8 @@ export class MultiStepFormSchema<
   }
 }
 
-export function createMultiStepFormSchema<
-  const TSteps extends StepConfig,
->(options: StepSchema.Config<TSteps>) {
-  return new MultiStepFormSchema<StepSchema.Config<TSteps>>(options);
+export function createMultiStepFormSchema<const steps extends StepConfig>(
+  options: StepSchema.Config<steps>,
+) {
+  return new MultiStepFormSchema<StepSchema.Config<steps>>(options);
 }

--- a/packages/core/src/steps/steps.ts
+++ b/packages/core/src/steps/steps.ts
@@ -86,6 +86,13 @@ export type StepDefaultValues<TFields extends FieldConfig<CasingType>> = {
 };
 
 type JustStepConfig<T> = Pick<T, keyof T & keyof Config>;
+type OverrideStepConfig<T> = T extends Config<
+  infer TFields,
+  infer TCasing,
+  infer TValidator
+>
+  ? Config<TFields, TCasing, TValidator>
+  : never;
 
 export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
   /**
@@ -115,7 +122,7 @@ export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
    */
   steps: {
     [key in keyof TMap]: JustStepConfig<TMap[key]> & {
-      overrides?: StepOverrides<TMap[key] & AnyConfig>;
+      overrides?: StepOverrides<OverrideStepConfig<TMap[key]>>;
     };
   };
 };

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -7,6 +7,7 @@ import {
   type HelperFnChosenSteps,
   MultiStepFormSchema as MultiStepFormSchemaCore,
   MultiStepFormStorage,
+  type StepConfig,
   type StepNumbers,
 } from '@jfdevelops/multi-step-form-core';
 import {
@@ -24,23 +25,22 @@ import { type instantiateReactSteps } from './steps';
 
 // Helper inference types for `AnyMultiStepFormSchema`
 export namespace MultiStepFormSchema {
-  export type resolvedStep<T> = T extends MultiStepFormSchema<infer _def, infer value>
-    ? value
-    : never;
+  export type resolvedStep<T> =
+    T extends MultiStepFormSchema<infer _def, infer value> ? value : never;
 
   export type withFormDef<
     def extends StepSchema.Config,
-    formConfig extends object
+    formConfig extends object,
   > = Expand<def & Readonly<{ form: formConfig }>>;
 
   export type withFormValue<
     def extends StepSchema.Config,
-    formConfig extends object
+    formConfig extends object,
   > = instantiateReactSteps<withFormDef<def, formConfig>>;
 
   export type config<
     def extends StepSchema.Config,
-    value extends instantiateReactSteps<def> = instantiateReactSteps<def>
+    value extends instantiateReactSteps<def> = instantiateReactSteps<def>,
   > = MultiStepFormStepSchema.config<def, value> & {
     /**
      * The React context for the multi step form.
@@ -54,9 +54,9 @@ export namespace MultiStepFormSchema {
 }
 
 export class MultiStepFormSchema<
-    const def extends StepSchema.Config,
-    value extends instantiateReactSteps<def> = instantiateReactSteps<def>
-  >
+  const def extends StepSchema.Config,
+  value extends instantiateReactSteps<def> = instantiateReactSteps<def>,
+>
   extends MultiStepFormSchemaCore<def>
   implements HelperFunctions<def, value>
 {
@@ -157,10 +157,8 @@ export class MultiStepFormSchema<
    * @param config The form configuration.
    * @returns A new {@linkcode MultiStepFormSchema} with the form configuration.
    */
-  withForm<
-    const formConfig extends object
-  >(
-    config: formConfig & MultiStepFormSchemaConfig.FormConfig<def, value>
+  withForm<const formConfig extends object>(
+    config: formConfig & MultiStepFormSchemaConfig.FormConfig<def, value>,
   ): MultiStepFormSchema<
     MultiStepFormSchema.withFormDef<def, formConfig>,
     MultiStepFormSchema.withFormValue<def, formConfig>
@@ -201,10 +199,10 @@ export class MultiStepFormSchema<
 
   createComponent<
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-    props = undefined
+    props = undefined,
   >(
     options: HelperFn.BaseOptions<value, chosenSteps>,
-    fn: CreateComponentCallback<value, chosenSteps, props>
+    fn: CreateComponentCallback<value, chosenSteps, props>,
   ) {
     return createComponent({
       fn,
@@ -218,8 +216,8 @@ export class MultiStepFormSchema<
   }
 }
 
-export function createMultiStepFormSchema<const def extends StepSchema.Config>(
-  options: def
+export function createMultiStepFormSchema<const steps extends StepConfig>(
+  options: StepSchema.Config<steps>,
 ) {
-  return new MultiStepFormSchema<def>(options);
+  return new MultiStepFormSchema<StepSchema.Config<steps>>(options);
 }

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { ComponentPropsWithRef, ReactElement } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
@@ -328,5 +328,110 @@ describe('step overrides', () => {
 
       return null;
     });
+  });
+
+  it('infers override fields at the react createMultiStepFormSchema entrypoint', () => {
+    createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            phoneNumber: {
+              defaultValue: '',
+            },
+            saveToAccount: {
+              defaultValue: false,
+            },
+          },
+          overrides: ({ fields }) => {
+            expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+            expectTypeOf(
+              fields.phoneNumber.defaultValue,
+            ).toEqualTypeOf<string>();
+            expectTypeOf(
+              fields.saveToAccount.defaultValue,
+            ).toEqualTypeOf<boolean>();
+
+            return {
+              firstName: fields.firstName.defaultValue,
+            };
+          },
+        },
+      },
+    });
+  });
+
+  it('preserves non-overridden fields through withForm and withContext', async () => {
+    const deferred = createDeferred<{ firstName: string }>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+            saveToAccount: {
+              defaultValue: false,
+            },
+          },
+          overrides: async ({ fields }) => {
+            expectTypeOf(
+              fields.saveToAccount.defaultValue,
+            ).toEqualTypeOf<boolean>();
+            expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+
+            const values = await deferred.promise;
+
+            return {
+              firstName: values.firstName,
+            };
+          },
+        },
+      },
+    })
+      .withForm({
+        render() {
+          return function Form(props: ComponentPropsWithRef<'form'>) {
+            return <form {...props} />;
+          };
+        },
+      })
+      .withContext();
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(
+      ({ Field, Form, Suspend }) => (
+        <Suspend fallback={<p data-testid='loading'>Loading</p>}>
+          <Form>
+            <Field name='firstName'>
+              {({ defaultValue }) => (
+                <p data-testid='firstName'>{String(defaultValue)}</p>
+              )}
+            </Field>
+            <Field name='saveToAccount'>
+              {({ defaultValue }) => (
+                <p data-testid='saveToAccount'>{String(defaultValue)}</p>
+              )}
+            </Field>
+          </Form>
+        </Suspend>
+      ),
+    );
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('loading').textContent).toBe('Loading');
+
+    await act(async () => {
+      deferred.resolve({
+        firstName: 'Jordan',
+      });
+    });
+
+    expect(screen.getByTestId('firstName').textContent).toBe('Jordan');
+    expect(screen.getByTestId('saveToAccount').textContent).toBe('false');
   });
 });


### PR DESCRIPTION
## Summary
- align the React `createMultiStepFormSchema(...)` factory typing with the core factory so step `overrides` callbacks receive properly inferred `fields`
- tighten core override typing for per-step config resolution
- add regression coverage for React override field inference and preserving omitted fields through `withForm()` and `withContext()`

## Verification
- pre-commit hook ran package tests and builds successfully
- added regression tests in `packages/react/test/step-schema/overrides.test.tsx`