### PR TITLE
feat(schema): support async step definitions

### DIFF
--- a/.changeset/bright-forks-share.md
+++ b/.changeset/bright-forks-share.md
@@ -1,0 +1,6 @@
+---
+"@jfdevelops/multi-step-form-core": patch
+"@jfdevelops/react-multi-step-form": patch
+---
+
+Fix async step resolution and reset behavior.

--- a/.changeset/quiet-lamps-grab.md
+++ b/.changeset/quiet-lamps-grab.md
@@ -1,0 +1,8 @@
+---
+'@jfdevelops/multi-step-form-core': minor
+'@jfdevelops/react-multi-step-form': minor
+---
+
+feat(core,react): support async step definitions without async schema creation
+
+Step definitions can now be provided as async functions that resolve to the existing step object shape while `createMultiStepFormSchema` stays synchronous. Async steps resolve lazily through the existing step resolution flow, and the React package keeps `createComponent`, `useStep`, and suspense behavior intact for sync, async, and mixed step definitions.

--- a/packages/core/src/internals/step-schema.ts
+++ b/packages/core/src/internals/step-schema.ts
@@ -11,7 +11,7 @@ import type { UpdateFn } from '@/steps/fn-utils/update-fn';
 import {
   instantiateSteps,
   type instantiateStepsConfig,
-  type StepConfig,
+  type instantiateAsyncStepsConfig,
   type StepNumbers,
 } from '@/steps/steps';
 import { functionalUpdate, omit } from '@/steps/utils';
@@ -105,11 +105,12 @@ export namespace MultiStepFormStepSchemaInternal {
 
 export namespace StepSchema {
   export type Config<
-    TSteps extends StepConfig = StepConfig,
+    TSteps extends instantiateAsyncStepsConfig['steps'] = instantiateAsyncStepsConfig['steps'],
     TCasing extends CasingType = DefaultCasing,
     TStorageKey extends string = string
-  > = instantiateStepsConfig<TSteps> &
-    NameTransformCasingOptions<TCasing> & {
+  > = {
+    steps: TSteps;
+  } & NameTransformCasingOptions<TCasing> & {
       /**
        * The options for the storage module.
        */
@@ -532,7 +533,7 @@ export class MultiStepFormStepSchemaInternal<
       prefix: (value) => `${value}:reset${targetStep}`,
     });
     const originalValues = instantiateSteps({
-      steps: this.#originalValue,
+      steps: this.#originalValue as instantiateStepsConfig['steps'],
     });
     const enrichedOriginalValues = this.enrichValues(
       originalValues,

--- a/packages/core/src/internals/step-schema.ts
+++ b/packages/core/src/internals/step-schema.ts
@@ -100,6 +100,9 @@ export namespace MultiStepFormStepSchemaInternal {
      * @returns
      */
     setValue: (value: value) => void;
+    getResetStepValue?: <targetStep extends StepNumbers<value>>(
+      step: targetStep,
+    ) => value[targetStep];
   }
 }
 
@@ -135,6 +138,9 @@ export class MultiStepFormStepSchemaInternal<
   readonly #additionalEnrichedProps?: (step: number) => additionalEnrichedProps;
   readonly #getValue: () => value;
   readonly #setValue: (value: value) => void;
+  readonly #getResetStepValue?: <targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) => value[targetStep];
 
   private get value() {
     return this.#getValue();
@@ -147,13 +153,20 @@ export class MultiStepFormStepSchemaInternal<
       additionalEnrichedProps
     >
   ) {
-    const { getValue, setValue, originalValue, additionalEnrichedProps } =
+    const {
+      getValue,
+      setValue,
+      originalValue,
+      additionalEnrichedProps,
+      getResetStepValue,
+    } =
       options;
 
     this.#originalValue = originalValue;
     this.#getValue = getValue;
     this.#setValue = setValue;
     this.#additionalEnrichedProps = additionalEnrichedProps;
+    this.#getResetStepValue = getResetStepValue;
   }
 
   private handlePostUpdate(value: value) {
@@ -532,26 +545,28 @@ export class MultiStepFormStepSchemaInternal<
       debug,
       prefix: (value) => `${value}:reset${targetStep}`,
     });
-    const originalValues = instantiateSteps({
-      steps: this.#originalValue as instantiateStepsConfig['steps'],
-    });
-    const enrichedOriginalValues = this.enrichValues(
-      originalValues,
-      this.#additionalEnrichedProps
-    ) as value;
+    const currentValues = this.value;
+    const resetStepValue =
+      this.#getResetStepValue?.(targetStep) ?? currentValues[targetStep];
+    const resetSourceValues = {
+      ...currentValues,
+      [targetStep]: resetStepValue,
+    } as value;
 
     if (fields === 'all') {
       logger.info(`Resetting all fields for ${targetStep}`);
-      this.handlePostUpdate(enrichedOriginalValues);
+      this.handlePostUpdate(resetSourceValues);
       logger.info(`Reset all fields for ${targetStep}`);
+
+      return;
     }
 
-    let updatedValues = { ...enrichedOriginalValues };
+    let updatedValues = { ...currentValues };
     const reset = this.resetFields<targetStep, currentStep>({
       logger,
       targetStep,
       updatedValues,
-      values: enrichedOriginalValues,
+      values: resetSourceValues,
     });
 
     if (HelperFnChosenSteps.isTuple<DeepKeys<currentStep>>(fields)) {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -7,7 +7,7 @@ import {
   type BaseStorageConfig,
 } from './storage.js';
 import { Subscribable } from './subscribable.js';
-import type { instantiateSteps, StepConfig } from './steps/steps.js';
+import type { instantiateSteps } from './steps/steps.js';
 
 export class MultiStepFormSchema<
   const def extends StepSchema.Config,
@@ -93,8 +93,8 @@ export class MultiStepFormSchema<
   }
 }
 
-export function createMultiStepFormSchema<const steps extends StepConfig>(
-  options: StepSchema.Config<steps>,
-) {
+export function createMultiStepFormSchema<
+  const steps extends StepSchema.Config['steps'],
+>(options: StepSchema.Config<steps>) {
   return new MultiStepFormSchema<StepSchema.Config<steps>>(options);
 }

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -30,6 +30,7 @@ import type { ResetFn } from './fn-utils/reset-fn';
 import type { UpdateFn } from './fn-utils/update-fn';
 import {
   type AnyConfig,
+  type AsyncStepDefinition,
   instantiateSteps,
   isValidSteps,
   type StepResolvedData,
@@ -429,6 +430,10 @@ export class MultiStepFormStepSchema<
     StepNumbers<value>,
     Record<string, unknown>
   >();
+  readonly #resolvedAsyncStepDefinitions = new Map<
+    StepNumbers<value>,
+    Record<string, unknown>
+  >();
   readonly #overrideState = new Map<
     StepNumbers<value>,
     StepOverrideResolutionState
@@ -449,8 +454,7 @@ export class MultiStepFormStepSchema<
     ) as def['nameTransformCasing'];
 
     this.original = steps;
-
-    this.value = instantiateSteps({ steps });
+    this.value = this.instantiateInitialSteps();
     this.#internal = new MultiStepFormStepSchemaInternal({
       originalValue: this.original,
       getValue: () => this.value,
@@ -465,15 +469,10 @@ export class MultiStepFormStepSchema<
       store: storage?.store,
       throwWhenUndefined: storage?.throwWhenUndefined,
     });
-    this.#stepNumbers = Object.keys(this.value).map((key) =>
+    this.#stepNumbers = Object.keys(this.original).map((key) =>
       Number.parseInt(key.replace('step', '')),
     );
-    for (const stepKey of Object.keys(this.value) as StepNumbers<value>[]) {
-      this.#baseDefaultValues.set(
-        stepKey,
-        getDefaultValues(this.value, stepKey) as Record<string, unknown>,
-      );
-    }
+    this.setBaseDefaultValues();
 
     this.steps = {
       value: this.#stepNumbers as unknown as ReadonlyArray<StepNumbers<value>>,
@@ -536,11 +535,63 @@ export class MultiStepFormStepSchema<
     this.initializeOverrideState();
   }
 
-  private initializeOverrideState() {
+  private instantiateInitialSteps() {
+    const resolvedSteps = Object.entries(this.original).reduce(
+      (acc, [stepKey, stepValue]) => {
+        if (typeof stepValue === 'function') {
+          acc[stepKey] = {
+            title: stepKey,
+            nameTransformCasing: this.defaultNameTransformationCasing,
+            fields: {},
+          };
+
+          return acc;
+        }
+
+        const instantiatedStep = instantiateSteps({
+          steps: {
+            [stepKey]: stepValue,
+          },
+        })[stepKey as keyof typeof acc];
+
+        acc[stepKey] = instantiatedStep;
+
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    );
+
+    return resolvedSteps as value;
+  }
+
+  private setBaseDefaultValues() {
     for (const stepKey of Object.keys(this.value) as StepNumbers<value>[]) {
+      const currentStep = this.value[stepKey] as {
+        fields?: Record<string, unknown>;
+      };
+
+      if (
+        typeof currentStep !== 'object' ||
+        currentStep === null ||
+        typeof currentStep.fields !== 'object' ||
+        Object.keys(currentStep.fields).length === 0
+      ) {
+        continue;
+      }
+
+      this.#baseDefaultValues.set(
+        stepKey,
+        getDefaultValues(this.value, stepKey) as Record<string, unknown>,
+      );
+    }
+  }
+
+  private initializeOverrideState() {
+    for (const stepKey of Object.keys(this.original) as StepNumbers<value>[]) {
       this.#overrideState.set(stepKey, {
         status:
-          this.hasOverrides(stepKey) && this.isStepUsingBaseDefaults(stepKey)
+          this.hasAsyncStepDefinition(stepKey) ||
+          (this.hasOverrides(stepKey) && this.isStepUsingBaseDefaults(stepKey))
             ? 'idle'
             : 'resolved',
       });
@@ -577,7 +628,9 @@ export class MultiStepFormStepSchema<
   private getStepOverride<targetStep extends StepNumbers<value>>(
     step: targetStep,
   ) {
-    const current = this.original[step as keyof def['steps']];
+    const current =
+      this.#resolvedAsyncStepDefinitions.get(step) ??
+      this.original[step as keyof def['steps']];
 
     if (!current || typeof current !== 'object') {
       return undefined;
@@ -650,6 +703,45 @@ export class MultiStepFormStepSchema<
     return this;
   }
 
+  private hasAsyncStepDefinition<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    return (
+      typeof this.original[step as keyof def['steps']] === 'function' &&
+      !this.#resolvedAsyncStepDefinitions.has(step)
+    );
+  }
+
+  private async resolveAsyncStepDefinition<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    if (!this.hasAsyncStepDefinition(step)) {
+      return;
+    }
+
+    const stepDefinition = this.original[
+      step as keyof def['steps']
+    ] as AsyncStepDefinition<AnyConfig>;
+    const resolvedStepDefinition = await stepDefinition();
+
+    this.#resolvedAsyncStepDefinitions.set(
+      step,
+      resolvedStepDefinition as Record<string, unknown>,
+    );
+
+    const instantiatedStep = instantiateSteps({
+      steps: {
+        [step]: resolvedStepDefinition,
+      },
+    })[step];
+
+    this.handlePostUpdate({
+      ...this.value,
+      [step]: instantiatedStep,
+    } as value);
+    this.setBaseDefaultValues();
+  }
+
   /**
    * Syncs the values from storage to {@linkcode value}.
    */
@@ -679,10 +771,6 @@ export class MultiStepFormStepSchema<
   async resolveStep<targetStep extends StepNumbers<value>>(
     step: targetStep,
   ) {
-    if (!this.hasOverrides(step)) {
-      return this.value[step];
-    }
-
     const currentState = this.getOverrideState(step);
 
     if (currentState.status === 'resolved') {
@@ -695,15 +783,20 @@ export class MultiStepFormStepSchema<
       return this.value[step];
     }
 
-    const override = this.getStepOverride(step);
+    const promise = this.resolveAsyncStepDefinition(step)
+      .then(async () => {
+        const override = this.getStepOverride(step);
 
-    invariant(
-      typeof override === 'function',
-      `[resolveStep]: "${step}" does not have a valid override resolver`,
-    );
+        if (typeof override !== 'function') {
+          this.setOverrideState(step, {
+            status: 'resolved',
+          });
 
-    const promise = Promise.resolve(override(this.getResolvedStepData(step)))
-      .then((overrides) => {
+          return;
+        }
+
+        const overrides = await override(this.getResolvedStepData(step));
+
         this.#overrideState.set(step, {
           status: 'resolved',
         });
@@ -741,10 +834,6 @@ export class MultiStepFormStepSchema<
   }
 
   suspendStep<targetStep extends StepNumbers<value>>(step: targetStep) {
-    if (!this.hasOverrides(step)) {
-      return this.value[step];
-    }
-
     const state = this.getOverrideState(step);
 
     if (state.status === 'resolved') {

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -459,6 +459,7 @@ export class MultiStepFormStepSchema<
       originalValue: this.original,
       getValue: () => this.value,
       setValue: (next) => this.handlePostUpdate(next),
+      getResetStepValue: (step) => this.getResetStepValue(step),
     });
 
     this.value = this.#internal.enrichValues(this.value);
@@ -566,24 +567,184 @@ export class MultiStepFormStepSchema<
 
   private setBaseDefaultValues() {
     for (const stepKey of Object.keys(this.value) as StepNumbers<value>[]) {
-      const currentStep = this.value[stepKey] as {
-        fields?: Record<string, unknown>;
-      };
+      this.setBaseDefaultValue(
+        stepKey,
+        this.value[stepKey] as Record<string, unknown>,
+      );
+    }
+  }
+
+  private setBaseDefaultValue<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+    stepValue: Record<string, unknown>,
+  ) {
+    const defaultValues = this.extractStepDefaultValues(stepValue);
+
+    if (!defaultValues) {
+      return;
+    }
+
+    this.#baseDefaultValues.set(step, defaultValues);
+  }
+
+  private extractStepDefaultValues(stepValue: Record<string, unknown>) {
+    if (
+      typeof stepValue !== 'object' ||
+      stepValue === null ||
+      !('fields' in stepValue) ||
+      typeof stepValue.fields !== 'object' ||
+      stepValue.fields === null ||
+      Object.keys(stepValue.fields).length === 0
+    ) {
+      return;
+    }
+
+    return Object.fromEntries(
+      Object.entries(stepValue.fields as Record<string, unknown>).map(
+        ([fieldName, fieldValue]) => [
+          fieldName,
+          typeof fieldValue === 'object' &&
+          fieldValue !== null &&
+          'defaultValue' in fieldValue
+            ? (fieldValue as { defaultValue: unknown }).defaultValue
+            : undefined,
+        ],
+      ),
+    );
+  }
+
+  private mergeResolvedStepWithCurrentValues<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+    resolvedStep: value[targetStep],
+  ) {
+    const currentStep = this.value[step] as {
+      fields?: Record<string, Record<string, unknown>>;
+    };
+    const nextStep = resolvedStep as value[targetStep] & {
+      fields?: Record<string, Record<string, unknown>>;
+    };
+
+    if (
+      typeof currentStep !== 'object' ||
+      currentStep === null ||
+      typeof currentStep.fields !== 'object' ||
+      currentStep.fields === null ||
+      typeof nextStep !== 'object' ||
+      nextStep === null ||
+      typeof nextStep.fields !== 'object' ||
+      nextStep.fields === null
+    ) {
+      return resolvedStep;
+    }
+
+    const nextFields = { ...nextStep.fields };
+    let hasMergedStoredValue = false;
+
+    for (const [fieldName, fieldValue] of Object.entries(currentStep.fields)) {
+      const resolvedField = nextFields[fieldName];
 
       if (
-        typeof currentStep !== 'object' ||
-        currentStep === null ||
-        typeof currentStep.fields !== 'object' ||
-        Object.keys(currentStep.fields).length === 0
+        typeof fieldValue !== 'object' ||
+        fieldValue === null ||
+        typeof resolvedField !== 'object' ||
+        resolvedField === null ||
+        !('defaultValue' in fieldValue) ||
+        !('defaultValue' in resolvedField)
       ) {
         continue;
       }
 
-      this.#baseDefaultValues.set(
-        stepKey,
-        getDefaultValues(this.value, stepKey) as Record<string, unknown>,
-      );
+      nextFields[fieldName] = {
+        ...resolvedField,
+        defaultValue: fieldValue.defaultValue,
+      };
+      hasMergedStoredValue = true;
     }
+
+    if (!hasMergedStoredValue) {
+      return resolvedStep;
+    }
+
+    return {
+      ...nextStep,
+      fields: nextFields,
+    } as value[targetStep];
+  }
+
+  protected getResetStepValue<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ) {
+    const fallbackStep = this.applyBaseDefaultValues(step, this.value[step]);
+    const resolvedDefinition = this.#resolvedAsyncStepDefinitions.get(step);
+    const originalStep =
+      resolvedDefinition ?? this.original[step as keyof def['steps']];
+
+    if (!originalStep || typeof originalStep === 'function') {
+      return fallbackStep;
+    }
+
+    try {
+      const instantiatedStep = instantiateSteps({
+        steps: {
+          [step]: originalStep,
+        },
+      })[step];
+
+      return this.applyBaseDefaultValues(
+        step,
+        this.#internal.enrichValues({
+          [step]: instantiatedStep,
+        } as Record<string, unknown>)[step] as value[targetStep],
+      );
+    } catch {
+      return fallbackStep;
+    }
+  }
+
+  private applyBaseDefaultValues<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+    stepValue: value[targetStep],
+  ) {
+    const baseDefaults = this.#baseDefaultValues.get(step);
+    const currentStep = stepValue as value[targetStep] & {
+      fields?: Record<string, Record<string, unknown>>;
+    };
+
+    if (
+      !baseDefaults ||
+      typeof currentStep !== 'object' ||
+      currentStep === null ||
+      typeof currentStep.fields !== 'object' ||
+      currentStep.fields === null
+    ) {
+      return stepValue;
+    }
+
+    const nextFields = { ...currentStep.fields };
+    let hasAppliedBaseDefaults = false;
+
+    for (const [fieldName, defaultValue] of Object.entries(baseDefaults)) {
+      const field = nextFields[fieldName];
+
+      if (typeof field !== 'object' || field === null) {
+        continue;
+      }
+
+      nextFields[fieldName] = {
+        ...field,
+        defaultValue,
+      };
+      hasAppliedBaseDefaults = true;
+    }
+
+    if (!hasAppliedBaseDefaults) {
+      return stepValue;
+    }
+
+    return {
+      ...currentStep,
+      fields: nextFields,
+    } as value[targetStep];
   }
 
   private initializeOverrideState() {
@@ -734,12 +895,19 @@ export class MultiStepFormStepSchema<
         [step]: resolvedStepDefinition,
       },
     })[step];
+    const mergedStep = this.mergeResolvedStepWithCurrentValues(
+      step,
+      instantiatedStep,
+    );
 
-    this.handlePostUpdate({
-      ...this.value,
-      [step]: instantiatedStep,
-    } as value);
-    this.setBaseDefaultValues();
+    this.setBaseDefaultValue(step, instantiatedStep as Record<string, unknown>);
+
+    this.handlePostUpdate(
+      this.#internal.enrichValues({
+        ...this.value,
+        [step]: mergedStep,
+      } as Record<string, unknown>) as value,
+    );
   }
 
   /**
@@ -770,7 +938,7 @@ export class MultiStepFormStepSchema<
 
   async resolveStep<targetStep extends StepNumbers<value>>(
     step: targetStep,
-  ) {
+  ): Promise<value[targetStep]> {
     const currentState = this.getOverrideState(step);
 
     if (currentState.status === 'resolved') {

--- a/packages/core/src/steps/steps.ts
+++ b/packages/core/src/steps/steps.ts
@@ -86,13 +86,25 @@ export type StepDefaultValues<TFields extends FieldConfig<CasingType>> = {
 };
 
 type JustStepConfig<T> = Pick<T, keyof T & keyof Config>;
-type OverrideStepConfig<T> = T extends Config<
+type OverrideStepConfig<T> = T extends AnyConfig
+  ? T
+  : T extends Config<
   infer TFields,
   infer TCasing,
   infer TValidator
 >
   ? Config<TFields, TCasing, TValidator>
   : never;
+type SyncStepDefinition<T> = (T extends {
+  title: string;
+  fields: FieldConfig<CasingType>;
+}
+  ? T
+  : JustStepConfig<T>) & {
+  overrides?: StepOverrides<OverrideStepConfig<T>>;
+};
+export type AsyncStepDefinition<T> = () =>
+  Promise<SyncStepDefinition<T>>;
 
 export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
   /**
@@ -119,11 +131,16 @@ export type instantiateStepsConfig<TMap extends StepConfig = StepConfig> = {
    *   },
    * }
    * ```
-   */
+  */
   steps: {
-    [key in keyof TMap]: JustStepConfig<TMap[key]> & {
-      overrides?: StepOverrides<OverrideStepConfig<TMap[key]>>;
-    };
+    [key in keyof TMap]: SyncStepDefinition<TMap[key]>;
+  };
+};
+export type instantiateAsyncStepsConfig<TMap extends StepConfig = StepConfig> = {
+  steps: {
+    [key in keyof TMap]:
+      | instantiateStepsConfig<TMap>['steps'][key]
+      | AsyncStepDefinition<TMap[key]>;
   };
 };
 /**
@@ -141,31 +158,44 @@ export interface StepExtension<
   _TKey extends keyof TValue,
 > {}
 
-export type _instantiateSteps<T = unknown> = [T] extends [object]
-  ? T extends instantiateStepsConfig
-    ? {
-        -readonly [key in keyof T['steps']]: Expand<
+type ResolvedStepConfig<T> = T extends AsyncStepDefinition<infer TConfig>
+  ? TConfig
+  : T;
+type InferStepMapFromConfig<T> = T extends {
+  steps: infer TSteps extends Record<string, unknown>;
+}
+  ? {
+      [key in keyof TSteps]: ResolvedStepConfig<TSteps[key]>;
+    }
+  : never;
+
+export type _instantiateSteps<T = unknown> =
+  [InferStepMapFromConfig<T>] extends [never]
+    ? {}
+    : {
+        -readonly [key in keyof InferStepMapFromConfig<T>]: Expand<
           {
             title: string;
             nameTransformCasing: inferNameTransformCasing<
-              T['steps'][key],
+              InferStepMapFromConfig<T>[key],
               DefaultCasing
             >;
             fields: StripStringIndex<
               instantiateFields<
-                T['steps'][key],
-                inferNameTransformCasing<T['steps'][key], DefaultCasing>
+                InferStepMapFromConfig<T>[key],
+                inferNameTransformCasing<
+                  InferStepMapFromConfig<T>[key],
+                  DefaultCasing
+                >
               >
             >;
-          } & (T['steps'][key] extends {
+          } & (InferStepMapFromConfig<T>[key] extends {
             description: infer description extends string;
           }
             ? { description: description }
             : {})
         >;
-      }
-    : {}
-  : {};
+      };
 export type BaseStepFunctions<
   def,
   value extends _instantiateSteps<def>,
@@ -199,6 +229,33 @@ export type getCurrentStep<
   value extends instantiateSteps,
   stepNumbers extends StepNumbers<value>,
 > = value[stepNumbers];
+
+function hasAsyncStepDefinition(steps: Record<string, unknown>) {
+  return Object.values(steps).some((stepValue) => typeof stepValue === 'function');
+}
+
+export function resolveStepDefinitions<const TMap extends StepConfig>(
+  steps: instantiateAsyncStepsConfig<TMap>['steps'],
+):
+  | instantiateStepsConfig<TMap>['steps']
+  | Promise<instantiateStepsConfig<TMap>['steps']> {
+  if (!hasAsyncStepDefinition(steps as Record<string, unknown>)) {
+    return steps as instantiateStepsConfig<TMap>['steps'];
+  }
+
+  return Promise.all(
+    Object.entries(steps).map(async ([stepKey, stepValue]) => {
+      const resolved =
+        typeof stepValue === 'function' ? await stepValue() : stepValue;
+
+      return [stepKey, resolved] as const;
+    }),
+  ).then((resolvedEntries) => {
+    return Object.fromEntries(
+      resolvedEntries,
+    ) as instantiateStepsConfig<TMap>['steps'];
+  });
+}
 
 export function instantiateSteps<
   const def extends instantiateStepsConfig,
@@ -240,7 +297,6 @@ export function instantiateSteps<
       nameTransformCasing = DEFAULT_CASING,
     } = stepValue;
 
-    // title validation
     invariant(title, 'A title must be provided for each step.', TypeError);
     invariant(
       typeof title === 'string',
@@ -281,7 +337,6 @@ export function instantiateSteps<
     resolvedSteps[stepKey] = {
       ...(resolvedSteps[stepKey] as Record<string, unknown>),
       title,
-      // Only add the description if it's defined
       ...(typeof description === 'string' ? { description } : {}),
       nameTransformCasing,
       fields: instantiatedFields,

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { createMultiStepFormSchema } from '../src';
+
+describe('createMultiStepFormSchema', () => {
+  it('creates a schema from fully sync step definitions', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        },
+        step2: {
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
+    expect(schema.stepSchema.value.step2.fields.age.defaultValue).toBe(0);
+  });
+
+  it('creates a schema synchronously from fully async step definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: async () => ({
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        }),
+        step2: async () => ({
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        }),
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('idle');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('idle');
+
+    const step1 = await schema.stepSchema.resolveStep('step1');
+    const step2 = await schema.stepSchema.resolveStep('step2');
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(step1.fields.firstName.defaultValue).toBe('');
+    expect(step2.fields.age.defaultValue).toBe(0);
+    expectTypeOf(step1.fields.firstName.defaultValue).toEqualTypeOf<string>();
+    expectTypeOf(step2.fields.age.defaultValue).toEqualTypeOf<number>();
+  });
+
+  it('creates a schema synchronously from mixed sync and async step definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        },
+        step2: async () => ({
+          title: 'Step 2',
+          description: 'Resolved asynchronously',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        }),
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('idle');
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
+
+    const step2 = await schema.stepSchema.resolveStep('step2');
+
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(step2.fields.age.defaultValue).toBe(0);
+    expect(step2.description).toBe('Resolved asynchronously');
+  });
+});

--- a/packages/core/test/step-schema/overrides.test.ts
+++ b/packages/core/test/step-schema/overrides.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createMultiStepFormSchema } from '../../src';
+import { createMockStorage } from '../utils/create-mock-storage';
 
 describe('multi step form step schema: overrides', () => {
   it('resolves async overrides for a single step', async () => {
@@ -94,6 +95,53 @@ describe('multi step form step schema: overrides', () => {
     expect(schema.stepSchema.getValue('step1', 'saveToAccount')).toBe(false);
     expect(schema.stepSchema.value.step1.fields.saveToAccount.defaultValue).toBe(
       false,
+    );
+  });
+
+  it('preserves persisted async step values when the step definition resolves', async () => {
+    const store = createMockStorage();
+    const storageKey = `async-step-persist-${Date.now()}`;
+    const createSchema = () =>
+      createMultiStepFormSchema({
+        storage: {
+          key: storageKey,
+          store,
+        },
+        steps: {
+          step1: async () => ({
+            title: 'Step 1',
+            description: 'Resolved asynchronously',
+            fields: {
+              firstName: {
+                defaultValue: 'Taylor',
+              },
+            },
+          }),
+        },
+      });
+
+    const initialSchema = createSchema();
+
+    await initialSchema.stepSchema.resolveStep('step1');
+    initialSchema.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Jordan',
+    });
+
+    const rehydratedSchema = createSchema();
+
+    expect(rehydratedSchema.stepSchema.getValue('step1', 'firstName')).toBe(
+      'Jordan',
+    );
+
+    await rehydratedSchema.stepSchema.resolveStep('step1');
+
+    expect(rehydratedSchema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(rehydratedSchema.stepSchema.getValue('step1', 'firstName')).toBe(
+      'Jordan',
+    );
+    expect(rehydratedSchema.stepSchema.value.step1.description).toBe(
+      'Resolved asynchronously',
     );
   });
 });

--- a/packages/core/test/step-schema/reset.test.ts
+++ b/packages/core/test/step-schema/reset.test.ts
@@ -70,6 +70,36 @@ describe('multi step form step schema: reset', () => {
     );
   });
 
+  it('resets async steps from resolved definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: async () => ({
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        }),
+      },
+    });
+
+    await schema.stepSchema.resolveStep('step1');
+    schema.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Jordan',
+    });
+
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+      'Jordan',
+    );
+
+    expect(() => schema.stepSchema.value.step1.reset()).not.toThrow();
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+      'Taylor',
+    );
+  });
+
   describe('tuple notation', () => {
     it('should reset the specified field', () => {
       const schema = createMultiStepFormSchema({

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -7,7 +7,6 @@ import {
   type HelperFnChosenSteps,
   MultiStepFormSchema as MultiStepFormSchemaCore,
   MultiStepFormStorage,
-  type StepConfig,
   type StepNumbers,
 } from '@jfdevelops/multi-step-form-core';
 import {
@@ -216,8 +215,8 @@ export class MultiStepFormSchema<
   }
 }
 
-export function createMultiStepFormSchema<const steps extends StepConfig>(
-  options: StepSchema.Config<steps>,
-) {
+export function createMultiStepFormSchema<
+  const steps extends StepSchema.Config['steps'],
+>(options: StepSchema.Config<steps>) {
   return new MultiStepFormSchema<StepSchema.Config<steps>>(options);
 }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -107,6 +107,7 @@ export class MultiStepFormStepSchema<
   private instantiatedForm?: ReturnType<
     ReturnType<typeof MultiStepFormSchemaConfig.instantiateFormConfig<def>>
   >;
+  readonly #initialFieldDefaultValues = new Map<string, unknown>();
 
   constructor(config: MultiStepFormStepSchema.config<def, value>) {
     const { form, ...rest } = config;
@@ -119,6 +120,7 @@ export class MultiStepFormStepSchema<
       originalValue: this.original,
       getValue: () => this.value,
       setValue: (next) => this.handlePostUpdate(next as never),
+      getResetStepValue: (step) => this.getResetStepValue(step as never),
     });
 
     const createFormConfig = MultiStepFormSchemaConfig.instantiateFormConfig(
@@ -144,6 +146,64 @@ export class MultiStepFormStepSchema<
     });
   }
 
+  private mergeStoredFieldValues<targetStep extends StepNumbers<value>>(
+    previousStep: value[targetStep],
+    nextStep: value[targetStep],
+  ) {
+    const current = previousStep as value[targetStep] & {
+      fields?: Record<string, Record<string, unknown>>;
+    };
+    const resolved = nextStep as value[targetStep] & {
+      fields?: Record<string, Record<string, unknown>>;
+    };
+
+    if (
+      typeof current !== 'object' ||
+      current === null ||
+      typeof current.fields !== 'object' ||
+      current.fields === null ||
+      typeof resolved !== 'object' ||
+      resolved === null ||
+      typeof resolved.fields !== 'object' ||
+      resolved.fields === null
+    ) {
+      return nextStep;
+    }
+
+    const fields = { ...resolved.fields };
+    let hasMergedStoredValue = false;
+
+    for (const [fieldName, fieldValue] of Object.entries(current.fields)) {
+      const resolvedField = fields[fieldName];
+
+      if (
+        typeof fieldValue !== 'object' ||
+        fieldValue === null ||
+        typeof resolvedField !== 'object' ||
+        resolvedField === null ||
+        !('defaultValue' in fieldValue) ||
+        !('defaultValue' in resolvedField)
+      ) {
+        continue;
+      }
+
+      fields[fieldName] = {
+        ...resolvedField,
+        defaultValue: fieldValue.defaultValue,
+      };
+      hasMergedStoredValue = true;
+    }
+
+    if (!hasMergedStoredValue) {
+      return nextStep;
+    }
+
+    return {
+      ...resolved,
+      fields,
+    } as value[targetStep];
+  }
+
   protected override handlePostUpdate(next: value) {
     super.handlePostUpdate(this.enrichWithReactHelpers(next));
   }
@@ -154,6 +214,27 @@ export class MultiStepFormStepSchema<
       return;
     }
     this.value = this.enrichWithReactHelpers(this.value);
+  }
+
+  override async resolveStep<targetStep extends StepNumbers<value>>(
+    step: targetStep,
+  ): Promise<value[targetStep]> {
+    const previousStep = this.value[step];
+    const shouldPreserveStoredValues =
+      typeof this.original[step as keyof def['steps']] === 'function';
+    const resolved = await super.resolveStep(step);
+    const mergedStep = shouldPreserveStoredValues
+      ? this.mergeStoredFieldValues(previousStep, this.value[step])
+      : this.value[step];
+
+    if (mergedStep !== this.value[step]) {
+      this.handlePostUpdate({
+        ...this.value,
+        [step]: mergedStep,
+      } as value);
+    }
+
+    return resolved;
   }
 
   private createResolvedCtx<
@@ -338,6 +419,7 @@ export class MultiStepFormStepSchema<
             const builtValuePath = buildValuePath(name);
             const fieldName = String(name);
             const [parentFieldName] = fieldName.split('.');
+            const resetFieldKey = `${step}:${builtValuePath}`;
             const fieldsRecord = currentStep.fields as Record<string, unknown>;
             const {
               label,
@@ -350,6 +432,10 @@ export class MultiStepFormStepSchema<
             };
 
             const targetFields = `fields.${builtValuePath}`;
+
+            if (!this.#initialFieldDefaultValues.has(resetFieldKey)) {
+              this.#initialFieldDefaultValues.set(resetFieldKey, defaultValue);
+            }
 
             return {
               defaultValue,
@@ -386,11 +472,16 @@ export class MultiStepFormStepSchema<
                 });
               },
               reset: (options?: UpdateFn.DebugOptions) =>
-                this.reset({
-                  fields: [targetFields] as never,
-                  targetStep: step,
+                this.update({
+                  partial: false,
+                  strict: true,
                   debug: options?.debug,
                   silentErrors: options?.silentErrors,
+                  targetStep: step,
+                  updater: this.#initialFieldDefaultValues.get(
+                    resetFieldKey,
+                  ) as never,
+                  fields: [targetFields] as never,
                 }),
             } as never;
           },

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -2,7 +2,6 @@ import {
   buildValuePath,
   createCtx,
   createInvariant,
-  instantiateSteps as instantiateStepsCore,
   type Expand,
   getDefaultValues,
   type HelperFn,
@@ -101,44 +100,60 @@ export class MultiStepFormStepSchema<
   implements HelperFunctions<def, value>
 {
   // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
-  value: value;
+  declare value: value;
   // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
-  readonly #internal: MultiStepFormStepSchemaInternal<def, value>;
+  private internal?: MultiStepFormStepSchemaInternal<def, value>;
+  private formId?: string;
+  private instantiatedForm?: ReturnType<
+    ReturnType<typeof MultiStepFormSchemaConfig.instantiateFormConfig<def>>
+  >;
 
   constructor(config: MultiStepFormStepSchema.config<def, value>) {
     const { form, ...rest } = config;
 
     super(rest as never);
-
-    this.value = instantiateStepsCore({ steps: this.original });
+    this.formId = form?.id;
 
     // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
-    this.#internal = new MultiStepFormStepSchemaInternal<def, value>({
+    this.internal = new MultiStepFormStepSchemaInternal<def, value>({
       originalValue: this.original,
       getValue: () => this.value,
       setValue: (next) => this.handlePostUpdate(next as never),
     });
 
-    this.sync();
-
     const createFormConfig = MultiStepFormSchemaConfig.instantiateFormConfig(
       this.value as never,
       this.steps.value
     );
-    const instantiatedForm = createFormConfig(form as never);
-    this.value = this.#internal.enrichValues(this.value, (step) => {
-      const targetStep = `step${step}` as StepNumbers<value>;
+    this.instantiatedForm = createFormConfig(form as never);
+    this.value = this.enrichWithReactHelpers(this.value);
+  }
 
-      const id = form?.id ?? targetStep;
+  private enrichWithReactHelpers(next: value) {
+    return this.internal!.enrichValues(next, (step) => {
+      const targetStep = `step${step}` as StepNumbers<value>;
+      const id = this.formId ?? targetStep;
 
       return {
         createComponent: this.createStepSpecificComponentFactory(targetStep, {
           isStepSpecific: true,
           defaultId: id,
-          form: instantiatedForm,
+          form: this.instantiatedForm,
         }),
       };
     });
+  }
+
+  protected override handlePostUpdate(next: value) {
+    super.handlePostUpdate(this.enrichWithReactHelpers(next));
+  }
+
+  override sync() {
+    super.sync();
+    if (!this.internal) {
+      return;
+    }
+    this.value = this.enrichWithReactHelpers(this.value);
   }
 
   private createResolvedCtx<
@@ -412,8 +427,8 @@ export class MultiStepFormStepSchema<
 
         let fnInput = {
           ctx: resolvedCtx,
-          onInputChange: this.#internal.createStepUpdaterFn(step),
-          reset: this.#internal.createStepResetterFn(step),
+          onInputChange: this.internal!.createStepUpdaterFn(step),
+          reset: this.internal!.createStepResetterFn(step),
           Field,
           Suspend: SuspendStep,
           useStep,
@@ -542,8 +557,8 @@ export class MultiStepFormStepSchema<
     return createComponent({
       fn,
       input: ({ stepData }) => ({
-        reset: this.#internal.createHelperFnInputReset(stepData),
-        update: this.#internal.createHelperFnInputUpdate(stepData),
+        reset: this.internal!.createHelperFnInputReset(stepData),
+        update: this.internal!.createHelperFnInputUpdate(stepData),
       }),
       options,
       value: this.value,

--- a/packages/react/test/field.test.tsx
+++ b/packages/react/test/field.test.tsx
@@ -176,4 +176,56 @@ describe('Field', () => {
     );
     expect(screen.getByTestId('defaultValue').textContent).toBe('Taylor');
   });
+
+  it('resets field values for resolved async step definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: async () => ({
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        }),
+      },
+    });
+
+    await schema.stepSchema.resolveStep('step1');
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }) => (
+      <Field name='firstName'>
+        {({ defaultValue, onInputChange, reset }) => (
+          <div>
+            <p data-testid='async-defaultValue'>{defaultValue}</p>
+            <button
+              data-testid='async-update'
+              onClick={() => onInputChange('Jordan')}
+            >
+              update
+            </button>
+            <button data-testid='async-reset' onClick={() => reset()}>
+              reset
+            </button>
+          </div>
+        )}
+      </Field>
+    ));
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('async-defaultValue').textContent).toBe('Taylor');
+
+    await act(async () => {
+      screen.getByTestId('async-update').click();
+    });
+
+    expect(screen.getByTestId('async-defaultValue').textContent).toBe('Jordan');
+
+    await act(async () => {
+      screen.getByTestId('async-reset').click();
+    });
+
+    expect(screen.getByTestId('async-defaultValue').textContent).toBe('Taylor');
+  });
 });

--- a/packages/react/test/schema.test.tsx
+++ b/packages/react/test/schema.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { createMultiStepFormSchema } from '../src';
+
+describe('createMultiStepFormSchema', () => {
+  it('creates a react schema from fully sync step definitions', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        },
+        step2: {
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        },
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
+    expect(schema.stepSchema.value.step2.fields.age.defaultValue).toBe(0);
+    expect(typeof schema.stepSchema.value.step1.createComponent).toBe('function');
+  });
+
+  it('creates a react schema synchronously from fully async step definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: async () => ({
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        }),
+        step2: async () => ({
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        }),
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('idle');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('idle');
+    expect(typeof schema.stepSchema.value.step1.createComponent).toBe('function');
+
+    const step1 = await schema.stepSchema.resolveStep('step1');
+    const step2 = await schema.stepSchema.resolveStep('step2');
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(step1.fields.firstName.defaultValue).toBe('');
+    expect(step2.fields.age.defaultValue).toBe(0);
+    expectTypeOf(step1.fields.firstName.defaultValue).toEqualTypeOf<string>();
+    expectTypeOf(step2.fields.age.defaultValue).toEqualTypeOf<number>();
+  });
+
+  it('creates a react schema synchronously from mixed sync and async step definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+            },
+          },
+        },
+        step2: async () => ({
+          title: 'Step 2',
+          description: 'Resolved asynchronously',
+          fields: {
+            age: {
+              defaultValue: 0,
+            },
+          },
+        }),
+      },
+    });
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('resolved');
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('idle');
+    expect(schema.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
+    expect(typeof schema.stepSchema.value.step2.createComponent).toBe('function');
+
+    const step2 = await schema.stepSchema.resolveStep('step2');
+
+    expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
+    expect(step2.fields.age.defaultValue).toBe(0);
+    expect(step2.description).toBe('Resolved asynchronously');
+    expect(typeof schema.stepSchema.value.step2.createComponent).toBe('function');
+  });
+});

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -69,6 +69,190 @@ function createDeferred<T>() {
 }
 
 describe('step overrides', () => {
+  it('useStep returns resolved data immediately for fully sync step definitions', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        },
+        step2: {
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: 42,
+            },
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ useStep }) => {
+      const { data, status, error } = useStep();
+
+      return (
+        <>
+          <p data-testid='status'>{status}</p>
+          <p data-testid='value'>{data.fields.firstName.defaultValue}</p>
+          <p data-testid='error'>{error === undefined ? 'none' : 'error'}</p>
+        </>
+      );
+    });
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('status').textContent).toBe('resolved');
+    expect(screen.getByTestId('value').textContent).toBe('Taylor');
+    expect(screen.getByTestId('error').textContent).toBe('none');
+  });
+
+  it('useStep resolves fully async step definitions without top-level schema await', async () => {
+    const firstName = createDeferred<string>();
+    const age = createDeferred<number>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: async () => ({
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: await firstName.promise,
+            },
+          },
+        }),
+        step2: async () => ({
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: await age.promise,
+            },
+          },
+        }),
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ useStep }) => {
+      const { data, status } = useStep();
+
+      return (
+        <>
+          <p data-testid='step1-status'>{status}</p>
+          <p data-testid='step1-value'>
+            {status === 'resolved'
+              ? data.fields.firstName.defaultValue
+              : 'pending'}
+          </p>
+        </>
+      );
+    });
+
+    const Step2 = schema.stepSchema.value.step2.createComponent(({ useStep }) => {
+      const { data, status } = useStep();
+
+      return (
+        <>
+          <p data-testid='step2-status'>{status}</p>
+          <p data-testid='step2-value'>
+            {status === 'resolved' ? String(data.fields.age.defaultValue) : 'pending'}
+          </p>
+        </>
+      );
+    });
+
+    const screen = await renderInJsdom(
+      <>
+        <Step1 />
+        <Step2 />
+      </>,
+    );
+
+    expect(screen.getByTestId('step1-value').textContent).toBe('pending');
+    expect(screen.getByTestId('step2-value').textContent).toBe('pending');
+
+    await act(async () => {
+      firstName.resolve('Jordan');
+      age.resolve(27);
+    });
+
+    expect(screen.getByTestId('step1-status').textContent).toBe('resolved');
+    expect(screen.getByTestId('step2-status').textContent).toBe('resolved');
+    expect(screen.getByTestId('step1-value').textContent).toBe('Jordan');
+    expect(screen.getByTestId('step2-value').textContent).toBe('27');
+  });
+
+  it('useStep handles mixed sync and async step definitions', async () => {
+    const asyncAge = createDeferred<number>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        },
+        step2: async () => ({
+          title: 'Step 2',
+          fields: {
+            age: {
+              defaultValue: await asyncAge.promise,
+            },
+          },
+        }),
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ useStep }) => {
+      const { data, status } = useStep();
+
+      return (
+        <>
+          <p data-testid='mixed-step1-status'>{status}</p>
+          <p data-testid='mixed-step1-value'>{data.fields.firstName.defaultValue}</p>
+        </>
+      );
+    });
+
+    const Step2 = schema.stepSchema.value.step2.createComponent(({ useStep }) => {
+      const { data, status } = useStep();
+
+      return (
+        <>
+          <p data-testid='mixed-step2-status'>{status}</p>
+          <p data-testid='mixed-step2-value'>
+            {status === 'resolved' ? String(data.fields.age.defaultValue) : 'pending'}
+          </p>
+        </>
+      );
+    });
+
+    const screen = await renderInJsdom(
+      <>
+        <Step1 />
+        <Step2 />
+      </>,
+    );
+
+    expect(screen.getByTestId('mixed-step1-status').textContent).toBe(
+      'resolved',
+    );
+    expect(screen.getByTestId('mixed-step1-value').textContent).toBe('Taylor');
+    expect(screen.getByTestId('mixed-step2-value').textContent).toBe('pending');
+
+    await act(async () => {
+      asyncAge.resolve(31);
+    });
+
+    expect(screen.getByTestId('mixed-step2-status').textContent).toBe(
+      'resolved',
+    );
+    expect(screen.getByTestId('mixed-step2-value').textContent).toBe('31');
+  });
+
   it('suspends the full step through Suspend', async () => {
     const deferred = createDeferred<{ firstName: string }>();
     const schema = createMultiStepFormSchema({

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -253,6 +253,80 @@ describe('step overrides', () => {
     expect(screen.getByTestId('mixed-step2-value').textContent).toBe('31');
   });
 
+  it('useStep preserves persisted async step values after the step resolves', async () => {
+    const storageKey = `react-async-step-persist-${Date.now()}`;
+    const seedSchema = createMultiStepFormSchema({
+      storage: {
+        key: storageKey,
+        store: window.localStorage,
+      },
+      steps: {
+        step1: async () => ({
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        }),
+      },
+    });
+
+    await seedSchema.stepSchema.resolveStep('step1');
+    seedSchema.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Jordan',
+    });
+
+    const deferred = createDeferred<{ title: string }>();
+    const schema = createMultiStepFormSchema({
+      storage: {
+        key: storageKey,
+        store: window.localStorage,
+      },
+      steps: {
+        step1: async () => ({
+          title: (await deferred.promise).title,
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        }),
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ useStep }) => {
+      const { data, status } = useStep();
+
+      return (
+        <>
+          <p data-testid='persisted-status'>{status}</p>
+          <p data-testid='persisted-value'>
+            {data.fields.firstName.defaultValue}
+          </p>
+          <p data-testid='persisted-title'>{data.title}</p>
+        </>
+      );
+    });
+
+    const screen = await renderInJsdom(<Step1 />);
+
+    expect(screen.getByTestId('persisted-value').textContent).toBe('Jordan');
+
+    await act(async () => {
+      deferred.resolve({
+        title: 'Resolved Step 1',
+      });
+    });
+
+    expect(screen.getByTestId('persisted-status').textContent).toBe('resolved');
+    expect(screen.getByTestId('persisted-value').textContent).toBe('Jordan');
+    expect(screen.getByTestId('persisted-title').textContent).toBe(
+      'Resolved Step 1',
+    );
+  });
+
   it('suspends the full step through Suspend', async () => {
     const deferred = createDeferred<{ firstName: string }>();
     const schema = createMultiStepFormSchema({

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   test: {
     name: packageJson.name,
     environment: 'jsdom',
+    pool: 'threads',
+    maxWorkers: 1,
+    fileParallelism: false,
     browser: useBrowserMode
       ? {
           enabled: true,


### PR DESCRIPTION
## Summary
- support async step definitions in core while keeping `createMultiStepFormSchema` synchronous
- lazily resolve async step definitions through the existing step resolution flow
- preserve React step APIs after async resolution and add coverage for sync, async, and mixed step definitions, including `useStep`
- configure the React Vitest pool to run reliably in this environment

## Testing
- `pnpm --filter @jfdevelops/multi-step-form-core test -- --run`
- `pnpm --filter @jfdevelops/react-multi-step-form test -- --run`
- pre-commit hook: `pnpm -r --filter "@jfdevelops/*" test --browser.headless=true`
- pre-commit hook build: `pnpm run build:core && pnpm run build:react`