### PR TITLE
fix(use-selector): support Date objects in deep equality

### DIFF
--- a/.changeset/tender-dates-compare.md
+++ b/.changeset/tender-dates-compare.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+fix: compare Date objects by timestamp in selectors

--- a/packages/react/src/hooks/use-selector.ts
+++ b/packages/react/src/hooks/use-selector.ts
@@ -10,9 +10,9 @@ import { useRef, useSyncExternalStore } from 'react';
 
 /**
  * Deep equality check that compares values regardless of property order.
- * Handles objects, arrays, primitives, and null/undefined.
+ * Handles objects, arrays, dates, primitives, and null/undefined.
  */
-function deepEqual(a: unknown, b: unknown): boolean {
+export function deepEqual(a: unknown, b: unknown) {
   // Same reference or both are the same primitive value
   if (a === b) {
     return true;
@@ -31,6 +31,15 @@ function deepEqual(a: unknown, b: unknown): boolean {
   // Both are primitives (but not equal due to first check)
   if (typeof a !== 'object') {
     return false;
+  }
+
+  // Dates are equal when their timestamps match, including invalid dates
+  if (a instanceof Date || b instanceof Date) {
+    return (
+      a instanceof Date &&
+      b instanceof Date &&
+      Object.is(a.getTime(), b.getTime())
+    );
   }
 
   // Both are arrays

--- a/packages/react/test/use-selector.test.ts
+++ b/packages/react/test/use-selector.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { deepEqual } from '../src/hooks/use-selector';
+
+describe('deepEqual', () => {
+  it('considers dates with the same timestamp equal', () => {
+    expect(
+      deepEqual(
+        new Date('2026-07-15T12:00:00.000Z'),
+        new Date('2026-07-15T12:00:00.000Z'),
+      )
+    ).toBe(true);
+  });
+
+  it('considers dates with different timestamps unequal', () => {
+    expect(
+      deepEqual(
+        new Date('2026-07-15T12:00:00.000Z'),
+        new Date('2026-07-15T13:00:00.000Z'),
+      )
+    ).toBe(false);
+  });
+
+  it('considers two invalid dates equal', () => {
+    expect(deepEqual(new Date('invalid'), new Date('invalid'))).toBe(true);
+  });
+
+  it('does not consider a date equal to a plain object', () => {
+    expect(deepEqual(new Date('2026-07-15T12:00:00.000Z'), {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- compare `Date` objects by timestamp in `deepEqual`
- prevent dates from comparing equal to plain objects
- add focused coverage for equal, unequal, and invalid dates
- include a patch changeset for the React package

## Why

`Date` instances have no enumerable properties, so the object comparison previously treated every pair of dates—and a date versus an empty object—as equal. Selectors could therefore retain stale values when a selected date changed.

## Impact

Selectors now detect timestamp changes while preserving stable references for equivalent date values.

## Validation

- package tests: 167 passed, 2 skipped, 5 todo
- core and React package builds passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to the selector equality helper with dedicated tests; no auth, data persistence, or API surface changes beyond exporting `deepEqual` for tests.
> 
> **Overview**
> Fixes selector stale updates when selected values include **`Date`** instances. **`deepEqual`** in `use-selector` now treats two dates as equal only when both are `Date` objects and their timestamps match via `Object.getTime()` (including invalid dates), and rejects date-vs-plain-object pairs instead of falling through to empty-key object equality.
> 
> **`deepEqual`** is exported for unit tests; new Vitest coverage covers same/different timestamps, invalid dates, and date vs `{}`. A patch **changeset** is included for `@jfdevelops/react-multi-step-form`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ce32e7a77d788f93850574dd6e1ed4b2c9ddd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->