### PR TITLE
fix(react): expose update in step components

### DIFF
--- a/.changeset/quick-forms-update.md
+++ b/.changeset/quick-forms-update.md
@@ -1,0 +1,6 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+'@jfdevelops/multi-step-form-core': patch
+---
+
+fix: expose the helper-style `update` API to step-specific components

--- a/packages/core/src/internals/step-schema.ts
+++ b/packages/core/src/internals/step-schema.ts
@@ -602,7 +602,7 @@ export class MultiStepFormStepSchemaInternal<
           {} as UpdateFn.createHelperFnForAllSteps<value, chosenSteps>
         );
         const update = Object.assign(
-          this.update,
+          this.update.bind(this),
           stepSpecificUpdateFn
         ) as UpdateFn.HelperFn<value, chosenSteps>;
 
@@ -618,7 +618,7 @@ export class MultiStepFormStepSchemaInternal<
           {} as UpdateFn.createHelperFnForObjectSteps<value, chosenSteps>
         );
         const update = Object.assign(
-          this.update,
+          this.update.bind(this),
           stepSpecificUpdateFn
         ) as UpdateFn.HelperFn<value, chosenSteps>;
 
@@ -633,7 +633,7 @@ export class MultiStepFormStepSchemaInternal<
           return acc;
         }, {} as UpdateFn.createHelperFnForTupleSteps<value, chosenSteps>);
         const update = Object.assign(
-          this.update,
+          this.update.bind(this),
           stepSpecificUpdateFn
         ) as UpdateFn.HelperFn<value, chosenSteps>;
 

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -412,6 +412,7 @@ export class MultiStepFormStepSchema<
 
         let fnInput = {
           ctx: resolvedCtx,
+          update: this.#internal.createHelperFnInputUpdate(stepData),
           onInputChange: this.#internal.createStepUpdaterFn(step),
           reset: this.#internal.createStepResetterFn(step),
           Field,

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -257,6 +257,9 @@ describe('creating components via "createComponent" fn', () => {
               foo: {
                 defaultValue: '',
               },
+              sibling: {
+                defaultValue: '',
+              },
             },
           },
           step2: {
@@ -283,7 +286,7 @@ describe('creating components via "createComponent" fn', () => {
           ComponentPropsWithRef<'form'>,
           MultiStepFormSchemaConfig.defaultEnabledFor
         >
-      >(({ ctx, onInputChange }) => (
+      >(({ ctx, onInputChange, update }) => (
         <div>
           <p>Step 1 Title: {ctx.step1.title}</p>
           <input
@@ -312,7 +315,7 @@ describe('creating components via "createComponent" fn', () => {
 
       expect(lastCall).toBeDefined();
 
-      const [{ ctx, onInputChange }] = lastCall!;
+      const [{ ctx, onInputChange, update }] = lastCall!;
 
       expect(ctx).toBeDefined();
       expect(ctx).toHaveProperty('step1');
@@ -327,6 +330,22 @@ describe('creating components via "createComponent" fn', () => {
       });
       expect(schema.stepSchema.value.step1.fields.foo.defaultValue).toBe(
         'New value',
+      );
+      expect(update).toBeTypeOf('function');
+      update({
+        targetStep: 'step1',
+        fields: ['fields.sibling.defaultValue'],
+        updater: () => 'Updated directly',
+      });
+      expect(schema.stepSchema.value.step1.fields.sibling.defaultValue).toBe(
+        'Updated directly',
+      );
+      update.step1({
+        fields: ['fields.sibling.defaultValue'],
+        updater: () => 'Updated through step helper',
+      });
+      expect(schema.stepSchema.value.step1.fields.sibling.defaultValue).toBe(
+        'Updated through step helper',
       );
     });
 


### PR DESCRIPTION
## Summary

- expose the helper-style `update` API in step-specific `createComponent` callbacks
- preserve both callable `update(...)` and step-scoped `update.stepN(...)` forms by binding the core update method
- add regression coverage and patch changesets for the React and core packages

## Root cause

The step-specific component input omitted `update`. The core helper factory also attached step-specific methods to an unbound `update` method, so invoking the callable form lost its internal instance context.

## Impact

Consumers can now destructure `update` from a step-specific component callback and update sibling fields using either supported helper form. Existing `onInputChange`, `reset`, field, form, and selector behavior remains unchanged.

## Validation

- core tests: 128 passed, 1 skipped, 2 todo
- React tests: 26 passed, 1 skipped, 3 todo
- core and React package builds passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared form state mutation paths in core and React step component wiring; scope is small but incorrect binding could break updates at runtime.
> 
> **Overview**
> Step-specific `createComponent` callbacks now receive **`update`** alongside `onInputChange` and `reset`, so consumers can change fields with the same helper API used elsewhere (`update({ targetStep, fields, updater })` and `update.stepN(...)`).
> 
> In core, the helper factory now **`bind`s** `this.update` before merging step-scoped methods, so the callable `update(...)` form keeps the correct instance context instead of losing `this` when invoked from a component.
> 
> Regression tests cover direct and `update.step1` updates on a sibling field; both packages get patch changesets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6651fd877ce24171dc9e685493ebbac092bdc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->