### PR TITLE
Fix suspended field remounts and add useStep selectors

### DIFF
--- a/.changeset/selective-step-state.md
+++ b/.changeset/selective-step-state.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Add optional selector options to `useStep` for granular subscriptions while preserving complete-result subscriptions when no selector is provided.

--- a/.changeset/steady-suspended-fields.md
+++ b/.changeset/steady-suspended-fields.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Prevent suspended fields from remounting their children during reactive updates, preserving DOM identity and focus.

--- a/packages/react/src/field.tsx
+++ b/packages/react/src/field.tsx
@@ -149,6 +149,12 @@ export namespace field {
   ) {
     const { propsCreator, subscribe, getValue, selectorCtx, suspendStep } = options;
 
+    function FieldResolutionGate({ children }: { children: ReactNode }) {
+      suspendStep?.();
+
+      return children;
+    }
+
     const Field: field.component<step> = (props) => {
       const { name, children, selectorFn } = props;
 
@@ -193,15 +199,9 @@ export namespace field {
       };
 
       if (props.suspend) {
-        function FieldResolutionGate() {
-          suspendStep?.();
-
-          return renderChildren();
-        }
-
         return (
           <Suspense fallback={props.fallback}>
-            <FieldResolutionGate />
+            <FieldResolutionGate>{renderChildren()}</FieldResolutionGate>
           </Suspense>
         );
       }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -23,7 +23,7 @@ import {
 } from '@jfdevelops/multi-step-form-core/_internals';
 import { field } from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
-import { createUseSelector } from './hooks/use-selector';
+import { createUseSelector, deepEqual } from './hooks/use-selector';
 import { selector } from './selector';
 import {
   type instantiateReactSteps,
@@ -41,9 +41,9 @@ import {
   Suspense,
   createElement,
   useEffect,
-  useSyncExternalStore,
   type ReactNode,
 } from 'react';
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 
 export type CreateComponentFn<
   def extends StepSchema.Config,
@@ -173,21 +173,76 @@ export class MultiStepFormStepSchema<
   private createUseStep<targetStep extends StepNumbers<value>>(
     step: targetStep,
   ): StepSpecificComponent.useStep<def, value, targetStep> {
-    return <TError = Error>() => {
-      const status = useSyncExternalStore(
+    type StepResult<TError extends Error = Error> =
+      StepSpecificComponent.useStepResult<value, targetStep, TError>;
+
+    let cachedSnapshot: StepResult | undefined;
+
+    const getSnapshot = () => {
+      const data = this.value[step] as HelperFnChosenSteps.currentStep<
+        value,
+        [targetStep]
+      >;
+      const status = this.getStepStatus(step as never);
+      const error = this.getStepError(step as never);
+
+      if (
+        cachedSnapshot &&
+        Object.is(cachedSnapshot.data, data) &&
+        Object.is(cachedSnapshot.status, status) &&
+        Object.is(cachedSnapshot.error, error)
+      ) {
+        return cachedSnapshot;
+      }
+
+      const nextSnapshot: StepResult = {
+        data,
+        status,
+        error: error as Error | undefined,
+      };
+      cachedSnapshot = nextSnapshot;
+
+      return nextSnapshot;
+    };
+
+    function identity<T>(result: T) {
+      return result;
+    }
+
+    function selectedValuesEqual(first: unknown, second: unknown) {
+      if (Object.is(first, second)) {
+        return true;
+      }
+
+      if (
+        first === null ||
+        second === null ||
+        typeof first !== 'object' ||
+        typeof second !== 'object'
+      ) {
+        return false;
+      }
+
+      return deepEqual(first, second);
+    }
+
+    const useStep = <TError extends Error = Error, TSelected = StepResult<TError>>(
+      options?: StepSpecificComponent.useStepOptions<
+        def,
+        value,
+        targetStep,
+        TError,
+        TSelected
+      >,
+    ) => {
+      const getTypedSnapshot = () => getSnapshot() as StepResult<TError>;
+      const selected = useSyncExternalStoreWithSelector(
         this.subscribe,
-        () => this.getStepStatus(step as never),
-        () => this.getStepStatus(step as never),
-      );
-      const data = useSyncExternalStore(
-        this.subscribe,
-        () => this.value[step],
-        () => this.value[step],
-      ) as HelperFnChosenSteps.currentStep<value, [targetStep]>;
-      const error = useSyncExternalStore(
-        this.subscribe,
-        () => this.getStepError(step as never),
-        () => this.getStepError(step as never),
+        getTypedSnapshot,
+        getTypedSnapshot,
+        options?.selector ??
+          (identity as (result: StepResult<TError>) => TSelected),
+        selectedValuesEqual,
       );
 
       useEffect(() => {
@@ -196,12 +251,10 @@ export class MultiStepFormStepSchema<
         });
       }, []);
 
-      return {
-        data,
-        status,
-        error: error as TError | undefined,
-      };
+      return selected;
     };
+
+    return useStep as StepSpecificComponent.useStep<def, value, targetStep>;
   }
 
   private createStepSuspend<targetStep extends StepNumbers<value>>(
@@ -337,7 +390,6 @@ export class MultiStepFormStepSchema<
                 validFields: allAvailableFields,
               },
             );
-
             InvalidInternalStateError.invariant(
               'update' in currentStep,
               {

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -118,15 +118,23 @@ export namespace StepSpecificComponent {
     status: OverrideStatus;
     error: TError | undefined;
   };
+  export type useStepOptions<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    error extends Error = Error,
+    selected = useStepResult<value, targetStep, error>,
+  > = {
+    error?: error;
+    selector?: (ctx: useStepResult<value, targetStep, error>) => selected;
+  };
   export type useStep<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
-  > = <error extends Error = Error>() => useStepResult<
-    value,
-    targetStep,
-    error
-  >;
+  > = <error extends Error = Error, selected = useStepResult<value, targetStep, error>>(
+    options?: useStepOptions<def, value, targetStep, error, selected>,
+  ) => selected;
 
   export type suspendProps = {
     children: ReactNode;
@@ -173,7 +181,28 @@ export namespace StepSpecificComponent {
        */
       Selector: selector.component<buildCurrentStep<def, value, targetStep>>;
       /**
-       * Reactively resolves the current step overrides and exposes the current resolution status.
+       * Reactively resolves the current step overrides and exposes its state.
+       *
+       * Calling `useStep()` subscribes to the complete `{ data, status, error }`
+       * result. Pass a selector in the options when the component only needs a
+       * small part of the step state; the component then rerenders only when
+       * that selected result changes. Object and array selections use
+       * structural equality.
+       *
+       * Event handlers that only need a value when invoked should prefer a
+       * non-reactive snapshot or getter when one is available.
+       *
+       * @example
+       * const firstName = useStep({
+       *   selector: ({ data }) => data.fields.firstName.defaultValue,
+       * });
+       *
+       * const contactDetails = useStep({
+       *   selector: ({ data }) => ({
+       *     email: data.fields.email.defaultValue,
+       *     phoneNumber: data.fields.phoneNumber.defaultValue,
+       *   }),
+       * });
        */
       useStep: useStep<def, value, targetStep>;
       /**

--- a/packages/react/test/field.test.tsx
+++ b/packages/react/test/field.test.tsx
@@ -17,6 +17,7 @@ afterEach(async () => {
     });
     container.remove();
   }
+  window.localStorage.clear();
 });
 
 async function renderInJsdom(ui: ReactElement) {
@@ -46,6 +47,55 @@ async function renderInJsdom(ui: ReactElement) {
 }
 
 describe('Field', () => {
+  it('preserves a suspended input node and focus after a value update', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+            },
+          },
+        },
+      },
+    });
+
+    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }) => (
+      <Field name='firstName' suspend fallback={<div>Loading</div>}>
+        {({ defaultValue, onInputChange }) => (
+          <input
+            data-testid='firstName'
+            value={defaultValue}
+            onChange={(event) => onInputChange(event.target.value)}
+          />
+        )}
+      </Field>
+    ));
+
+    const screen = await renderInJsdom(<Step1 />);
+    const originalInput = screen.getByTestId('firstName') as HTMLInputElement;
+
+    originalInput.focus();
+    expect(document.activeElement).toBe(originalInput);
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set;
+
+      valueSetter?.call(originalInput, 'Jordan');
+      originalInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    const updatedInput = screen.getByTestId('firstName') as HTMLInputElement;
+
+    expect(updatedInput).toBe(originalInput);
+    expect(document.activeElement).toBe(originalInput);
+    expect(updatedInput.value).toBe('Jordan');
+  });
+
   it('renders each children property to the dom', async () => {
     const date = new Date('2024-01-01T00:00:00.000Z');
     const schema = createMultiStepFormSchema({

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -286,7 +286,7 @@ describe('creating components via "createComponent" fn', () => {
           ComponentPropsWithRef<'form'>,
           MultiStepFormSchemaConfig.defaultEnabledFor
         >
-      >(({ ctx, onInputChange, update }) => (
+      >(({ ctx, onInputChange }) => (
         <div>
           <p>Step 1 Title: {ctx.step1.title}</p>
           <input

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -1,7 +1,8 @@
 import type { ComponentPropsWithRef, ReactElement } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
+import type { OverrideStatus } from '@jfdevelops/multi-step-form-core';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { createMultiStepFormSchema } from '../../src';
 
 (
@@ -202,6 +203,161 @@ describe('step overrides', () => {
     expect(screen.getByTestId('value').textContent).toBe('Jordan');
   });
 
+  it('isolates primitive and object useStep selectors', async () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: { defaultValue: 'Taylor' },
+            lastName: { defaultValue: 'Smith' },
+            email: { defaultValue: 'taylor@example.com' },
+            phoneNumber: { defaultValue: '555-0100' },
+          },
+        },
+      },
+    });
+    const firstNameRender = vi.fn();
+    const contactDetailsRender = vi.fn();
+
+    const FirstName = schema.stepSchema.value.step1.createComponent(
+      ({ useStep }) => {
+        const firstName = useStep({
+          selector: ({ data }) => data.fields.firstName.defaultValue,
+        });
+        firstNameRender();
+
+        return <p data-testid='selected-first-name'>{firstName}</p>;
+      },
+    );
+    const ContactDetails = schema.stepSchema.value.step1.createComponent(
+      ({ useStep }) => {
+        const contactDetails = useStep({
+          selector: ({ data }) => ({
+            email: data.fields.email.defaultValue,
+            phoneNumber: data.fields.phoneNumber.defaultValue,
+          }),
+        });
+        contactDetailsRender();
+
+        return <p data-testid='contact-details'>{contactDetails.email}</p>;
+      },
+    );
+    const Controls = schema.stepSchema.value.step1.createComponent(
+      ({ Field }) => (
+        <>
+          <Field name='lastName'>
+            {({ onInputChange }) => (
+              <button
+                data-testid='update-last-name'
+                onClick={() => onInputChange('Jones')}
+              />
+            )}
+          </Field>
+          <Field name='firstName'>
+            {({ onInputChange }) => (
+              <button
+                data-testid='update-first-name'
+                onClick={() => onInputChange('Jordan')}
+              />
+            )}
+          </Field>
+          <Field name='email'>
+            {({ onInputChange }) => (
+              <button
+                data-testid='update-email'
+                onClick={() => onInputChange('jordan@example.com')}
+              />
+            )}
+          </Field>
+        </>
+      ),
+    );
+
+    const screen = await renderInJsdom(
+      <>
+        <FirstName />
+        <ContactDetails />
+        <Controls />
+      </>,
+    );
+
+    expect(firstNameRender).toHaveBeenCalledTimes(1);
+    expect(contactDetailsRender).toHaveBeenCalledTimes(1);
+
+    await act(async () => screen.getByTestId('update-last-name').click());
+
+    expect(firstNameRender).toHaveBeenCalledTimes(1);
+    expect(contactDetailsRender).toHaveBeenCalledTimes(1);
+
+    await act(async () => screen.getByTestId('update-first-name').click());
+
+    expect(firstNameRender).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('selected-first-name').textContent).toBe(
+      'Jordan',
+    );
+    expect(contactDetailsRender).toHaveBeenCalledTimes(1);
+
+    await act(async () => screen.getByTestId('update-email').click());
+
+    expect(contactDetailsRender).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('contact-details').textContent).toBe(
+      'jordan@example.com',
+    );
+  });
+
+  it('resolves overrides and isolates a status selector from field updates', async () => {
+    const deferred = createDeferred<{ firstName: string }>();
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: { defaultValue: '' },
+          },
+          overrides: async () => deferred.promise,
+        },
+      },
+    });
+    const statusRender = vi.fn();
+
+    const Status = schema.stepSchema.value.step1.createComponent(
+      ({ useStep, Field }) => {
+        const status = useStep({
+          selector: (result) => result.status,
+        });
+        statusRender(status);
+
+        return (
+          <>
+            <p data-testid='selected-status'>{status}</p>
+            <Field name='firstName'>
+              {({ onInputChange }) => (
+                <button
+                  data-testid='update-resolved-field'
+                  onClick={() => onInputChange('Alex')}
+                />
+              )}
+            </Field>
+          </>
+        );
+      },
+    );
+
+    const screen = await renderInJsdom(<Status />);
+
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('loading');
+
+    await act(async () => deferred.resolve({ firstName: 'Jordan' }));
+
+    expect(screen.getByTestId('selected-status').textContent).toBe('resolved');
+    const renderCountAfterResolution = statusRender.mock.calls.length;
+
+    await act(async () => screen.getByTestId('update-resolved-field').click());
+
+    expect(statusRender).toHaveBeenCalledTimes(renderCountAfterResolution);
+  });
+
   it('keeps non-overridden fields available after async step resolution', async () => {
     const deferred = createDeferred<{ firstName: string }>();
     const schema = createMultiStepFormSchema({
@@ -318,13 +474,33 @@ describe('step overrides', () => {
 
     schema.stepSchema.value.step1.createComponent(({ useStep }) => {
       const defaultResult = useStep();
-      const customResult = useStep<CustomError>();
+      const undefinedSelectorResult = useStep(undefined);
+      const error = new CustomError('Failed to load step defaults');
+      const customResult = useStep({
+        error,
+      });
+      const firstName = useStep({
+        selector: ({ data }) => data.fields.firstName.defaultValue,
+      });
+      const status = useStep({
+        selector: (result) => result.status,
+      });
+      const customError = useStep({
+        error,
+        selector: (result) => result.error,
+      });
 
       expectTypeOf(
         defaultResult.data.fields.firstName.defaultValue,
       ).toEqualTypeOf<string>();
       expectTypeOf(defaultResult.error).toEqualTypeOf<Error | undefined>();
+      expectTypeOf(
+        undefinedSelectorResult.data.fields.firstName.defaultValue,
+      ).toEqualTypeOf<string>();
       expectTypeOf(customResult.error).toEqualTypeOf<CustomError | undefined>();
+      expectTypeOf(firstName).toEqualTypeOf<string>();
+      expectTypeOf(status).toEqualTypeOf<OverrideStatus>();
+      expectTypeOf(customError).toEqualTypeOf<CustomError | undefined>();
 
       return null;
     });


### PR DESCRIPTION
## Summary

- preserve suspended `Field` child identity across reactive value updates so focused inputs stay focused
- add optional selector options to `useStep` for granular subscriptions to data, status, or errors
- preserve complete-result `useStep()` subscriptions when no selector is provided
- add separate patch changesets for both improvements

## Root causes

`FieldResolutionGate` was declared inside the reactive `Field` render path, giving React a new component type after every field update and remounting the child subtree.

`useStep` subscribed independently to the complete step data, status, and error snapshots, so callers rerendered for changes they did not consume.

## Impact

Suspended fields now retain their DOM nodes and focus during input updates. Components can use `useStep({ selector })` to rerender only when the selected value changes, including structural equality for object and array selections.

## Validation

- core package tests: 136 passed, 1 skipped, 2 todo
- React package tests: 29 passed, 1 skipped, 3 todo
- core and React package builds passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `useStep` subscription semantics change internally (single selector path vs three stores), which could affect rerender timing for existing callers even though the no-selector API is preserved.
> 
> **Overview**
> Fixes **suspended `Field` remounts** by hoisting `FieldResolutionGate` outside the reactive `Field` render path and rendering field children as stable `children` instead of defining a new gate component on every update, so inputs keep the same DOM node and focus while values change.
> 
> Adds **optional `useStep` selectors** via `useSyncExternalStoreWithSelector`, a cached `{ data, status, error }` snapshot, and structural equality for object/array selections. `useStep()` with no selector still returns the full result; callers can pass `selector` (and optional custom `error` typing) to rerender only when the chosen slice changes.
> 
> Ships two patch changesets and expands tests for focus retention, selector isolation, and updated `useStep` typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15beff8c53f3f1cfc97b9f1087e470802abdafbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->