### PR TITLE
fix(release): reset beta prerelease versions

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @jfdevelops/multi-step-form-core
 
-## 1.0.0-beta.38
+## 1.0.0-beta.0
 
 ### Major Changes
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jfdevelops/multi-step-form-core",
-  "version": "1.0.0-beta.38",
+  "version": "1.0.0-beta.0",
   "description": "",
   "repository": "https://github.com/jfdevelops/multi-step-form",
   "type": "module",

--- a/packages/core/test/step-schema/name-transforming-case.test.ts
+++ b/packages/core/test/step-schema/name-transforming-case.test.ts
@@ -1,7 +1,53 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import { createMultiStepFormSchema } from '../../src';
 
 describe('multi step form step schema: name transform casing', () => {
+  it('uses the schema-wide casing for field labels', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: { title: 'Step 1', fields: { firstName: { defaultValue: '' } } },
+      },
+      nameTransformCasing: 'camel',
+    });
+
+    type Label = typeof schema.stepSchema.value.step1.fields.firstName.label;
+    expectTypeOf<Label>().toEqualTypeOf<'firstName'>();
+    expect(schema.stepSchema.value.step1.fields.firstName.label).toBe(
+      'firstName',
+    );
+  });
+
+  it('defaults schema-wide field labels to title casing', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: { title: 'Step 1', fields: { firstName: { defaultValue: '' } } },
+      },
+    });
+
+    type Label = typeof schema.stepSchema.value.step1.fields.firstName.label;
+    expectTypeOf<Label>().toEqualTypeOf<'First Name'>();
+    expect(schema.stepSchema.value.step1.fields.firstName.label).toBe(
+      'First Name',
+    );
+  });
+
+  it('prefers the step casing over the schema-wide casing', () => {
+    const schema = createMultiStepFormSchema({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          nameTransformCasing: 'snake',
+          fields: { firstName: { defaultValue: '' } },
+        },
+      },
+      nameTransformCasing: 'camel',
+    });
+
+    expect(schema.stepSchema.value.step1.fields.firstName.label).toBe(
+      'first_name',
+    );
+  });
+
   it('should assign a default name transform casing to the step', () => {
     const schema = createMultiStepFormSchema({
       steps: {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @jfdevelops/react-multi-step-form
 
-## 1.0.0-beta.56
+## 1.0.0-beta.0
 
 ### Major Changes
 
@@ -14,7 +14,7 @@
 
 - Updated dependencies [a44ace5]
 - Updated dependencies [85e4f84]
-  - @jfdevelops/multi-step-form-core@1.0.0-beta.38
+  - @jfdevelops/multi-step-form-core@1.0.0-beta.0
 
 ## 1.0.0-alpha.55
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jfdevelops/react-multi-step-form",
-  "version": "1.0.0-beta.56",
+  "version": "1.0.0-beta.0",
   "description": "",
   "repository": "https://github.com/jfdevelops/multi-step-form",
   "type": "module",


### PR DESCRIPTION
## Summary

- reset both package versions to `1.0.0-beta.0`
- align the core and React changelogs, including the internal core dependency entry
- add regression coverage for schema-wide field-label casing, its title-case default, and step-level overrides

## Why

The alpha-to-beta transition changed the prerelease tag, but the generated versions inherited the existing alpha counters, producing `beta.38` and `beta.56`. The beta line should begin at `.0` for both packages.

## Impact

The package metadata now represents the intended first beta release, and future prerelease increments can continue from `beta.0`.

## Validation

- package test suites passed through the pre-commit hook
- core and React package builds passed through the pre-commit hook
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and test-only changes; no application runtime logic is modified in this diff.
> 
> **Overview**
> Resets **@jfdevelops/multi-step-form-core** and **@jfdevelops/react-multi-step-form** from inherited `beta.38` / `beta.56` counters to **`1.0.0-beta.0`**, so the beta line starts at `.0` after the alpha→beta tag change.
> 
> **Changelogs** and the React package’s core dependency entry are updated to match. The React changelog also drops a redundant patch note for the beta transition that already appears under major changes.
> 
> Adds **core regression tests** for `nameTransformCasing`: schema-wide casing (with typed labels), default title casing when omitted, and step-level casing overriding the schema default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433d76447227f9f37482d8f21ba4413be0daf39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->