### PR TITLE
fix(react): harden beta form and component APIs

### DIFF
--- a/.changeset/bright-beta-api-fixes.md
+++ b/.changeset/bright-beta-api-fixes.md
@@ -1,0 +1,8 @@
+---
+"@jfdevelops/multi-step-form-core": major
+"@jfdevelops/react-multi-step-form": major
+---
+
+Restore the complete schema surface on form definitions, including a type-only exact step union, while keeping configured instances independent.
+
+Return `NoCurrentData` and `ProgressText` components from render-context helpers, align single-step instance components with step-specific render inputs, and replace every `createComponent` overload with the object-only `{ render }` API.

--- a/.changeset/calm-fields-forward.md
+++ b/.changeset/calm-fields-forward.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Correct `createComponent.forField` return props so generated components forward Field options other than the internally owned `name` and `children`, while continuing to infer and accept custom render props.

--- a/.changeset/warm-fields-compose.md
+++ b/.changeset/warm-fields-compose.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': minor
+---
+
+Add strongly typed `createComponent.forField` factories at schema, step, definition, and configured-factory levels. Configured factories reuse the component definition across active instances while keeping each instance's state and subscriptions isolated.

--- a/README.md
+++ b/README.md
@@ -29,75 +29,79 @@ npm install @jfdevelops/multi-step-form @jfdevelops/react-multi-step-form
 ### 1. Create a Form Schema
 
 ```tsx
-import { defineMultiStepForm } from '@jfdevelops/react-multi-step-form';
+import { defineMultiStepForm } from "@jfdevelops/react-multi-step-form";
 
-const createForm = defineMultiStepForm({
+const definedForm = defineMultiStepForm({
   steps: {
     step1: {
-      title: 'Personal Information',
+      title: "Personal Information",
       fields: {
         firstName: {
-          defaultValue: '',
+          defaultValue: "",
         },
         lastName: {
-          defaultValue: '',
+          defaultValue: "",
         },
         email: {
-          defaultValue: '',
-          type: 'string.email',
+          defaultValue: "",
+          type: "string.email",
         },
       },
     },
     step2: {
-      title: 'Account/Preferences',
+      title: "Account/Preferences",
       fields: {
         username: {
-          defaultValue: '',
+          defaultValue: "",
         },
         password: {
-          defaultValue: '',
+          defaultValue: "",
         },
         language: {
-          defaultValue: 'en',
-          label: 'Preferred Language',
+          defaultValue: "en",
+          label: "Preferred Language",
         },
       },
     },
     step3: {
-      title: 'Confirmation',
+      title: "Confirmation",
       fields: {
         newsLetterOptIn: {
           defaultValue: false,
-          type: 'boolean.switch',
+          type: "boolean.switch",
         },
       },
     },
   },
-}).configure({
+});
+
+export type StepNumber = typeof definedForm.stepNumbers;
+
+const createForm = definedForm.configure({
   storage: {
-    key: 'MultiStepFormBasicExample',
+    key: "MultiStepFormBasicExample",
   },
 });
 
 export const schema = createForm()
   .withForm({
-    alias: 'MyCoolCustomForm',
-    enabledForSteps: ['step1', 'step2'],
+    alias: "MyCoolCustomForm",
+    enabledForSteps: ["step1", "step2"],
     render(
       { id },
       {
         title,
         description,
         ...props
-      }: ComponentPropsWithRef<'form'> & {
+      }: ComponentPropsWithRef<"form"> & {
         title: string;
         description?: string;
-      }
+      },
     ) {
       return (
-        <div className='flex flex-col gap-y-4'>
-          <div className='flex flex-col gap-y-2'>
-            <h1 className='font-bold text-xl'>{title}</h1>
+        <div className="flex flex-col gap-y-4">
+          <div className="flex flex-col gap-y-2">
+            <h1 className="font-bold text-xl">{title}</h1>
             {description && <p>{description}</p>}
           </div>
           <form id={id} {...props} />
@@ -113,11 +117,11 @@ export const {
   useProgress,
   useCanRestartForm,
 } = schema.context;
-
-export type StepNumber = keyof MultiStepFormSchema.resolvedStep<typeof schema>;
 ```
 
-`defineMultiStepForm({ steps }).configure({ storage })` is a single-instance form by default — see
+The value returned by `defineMultiStepForm({ steps })` is a complete schema, including
+`stepSchema`, `withForm`, and (in React) `createComponent`. Calling `.configure({ storage })`
+adds a factory for independent instances that share its shape but not its state. See
 the [beta docs](#beta-instances--storage) below for named instances (e.g. a persisted public form
 alongside a memory-only admin form) sharing this same definition. The pre-beta
 `createMultiStepFormSchema` factory has been removed; see the migration guides below for moving
@@ -126,50 +130,50 @@ its configuration into `defineMultiStepForm(...).configure(...)`.
 ### 2. Create step specific components
 
 ```tsx
-import { schema } from './schema';
+import { schema } from "./schema";
 
-export const Step1 = schema.stepSchema.value.step1.createComponent(
-  function Step1({ ctx, MyCoolCustomForm, Field: FieldComponent }) {
+export const Step1 = schema.stepSchema.value.step1.createComponent({
+  render: function Step1({ ctx, MyCoolCustomForm, Field: FieldComponent }) {
     const { title } = ctx.step1;
 
     return (
       <MyCoolCustomForm title={title}>
         <FieldSet>
-          <FieldComponent name='firstName'>
+          <FieldComponent name="firstName">
             {({ defaultValue, label, onInputChange }) => (
               <Field>
                 <FieldLabel htmlFor={label}>{label}</FieldLabel>
                 <Input
                   id={label}
                   defaultValue={defaultValue}
-                  placeholder='John'
+                  placeholder="John"
                   onChange={(e) => onInputChange(e.target.value)}
                 />
               </Field>
             )}
           </FieldComponent>
-          <FieldComponent name='lastName'>
+          <FieldComponent name="lastName">
             {({ defaultValue, label, onInputChange }) => (
               <Field>
                 <FieldLabel htmlFor={label}>{label}</FieldLabel>
                 <Input
                   id={label}
                   defaultValue={defaultValue}
-                  placeholder='Smith'
+                  placeholder="Smith"
                   onChange={(e) => onInputChange(e.target.value)}
                 />
               </Field>
             )}
           </FieldComponent>
-          <FieldComponent name='email'>
+          <FieldComponent name="email">
             {({ defaultValue, label, onInputChange }) => (
               <Field>
                 <FieldLabel htmlFor={label}>{label}</FieldLabel>
                 <Input
                   id={label}
                   defaultValue={defaultValue}
-                  placeholder='johnsmith@gmail.com'
-                  type='email'
+                  placeholder="johnsmith@gmail.com"
+                  type="email"
                   onChange={(e) => onInputChange(e.target.value)}
                 />
               </Field>
@@ -178,8 +182,8 @@ export const Step1 = schema.stepSchema.value.step1.createComponent(
         </FieldSet>
       </MyCoolCustomForm>
     );
-  }
-);
+  },
+});
 
 // more step components
 ```
@@ -187,8 +191,8 @@ export const Step1 = schema.stepSchema.value.step1.createComponent(
 ### 3. Create a "Step Layout"
 
 ```tsx
-import { useCurrentStepData, type StepNumber } from './schema';
-import { Step1, Step2 } from './steps';
+import { useCurrentStepData, type StepNumber } from "./schema";
+import { Step1, Step2 } from "./steps";
 
 export function StepLayout({
   currentStep: stepNumber,
@@ -221,14 +225,17 @@ internal/admin form that share the same steps and helper functions:
 
 ```ts
 const createBookingForm = defineMultiStepForm({
-  steps: { /* ... */ },
-  instances: ['admin', 'client'],
+  steps: {/* ... */},
+  instances: ["admin", "client"],
 }).configure({
-  storage: { key: { client: 'booking:client', admin: 'booking:admin' }, configure: { instances: ['client'] } },
+  storage: {
+    key: { client: "booking:client", admin: "booking:admin" },
+    configure: { instances: ["client"] },
+  },
 });
 
-const clientForm = createBookingForm({ instance: 'client' }); // persists to storage
-const adminForm = createBookingForm({ instance: 'admin' }); // memory-only
+const clientForm = createBookingForm({ instance: "client" }); // persists to storage
+const adminForm = createBookingForm({ instance: "admin" }); // memory-only
 ```
 
 See the per-package docs for the full guide — instances, per-instance storage, shared
@@ -306,7 +313,7 @@ The library provides full TypeScript support with type inference:
 
 ```tsx
 type StepNumber = keyof MultiStepFormSchema.resolvedStep<typeof schema>;
-type Step1Data = MultiStepFormSchema.getData<typeof schema, 'step1'>;
+type Step1Data = MultiStepFormSchema.getData<typeof schema, "step1">;
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -188,6 +188,32 @@ export const Step1 = schema.stepSchema.value.step1.createComponent({
 // more step components
 ```
 
+Create reusable field components directly from a schema or a specific step. The render callback
+receives the resolved field value, metadata, and update/reset helpers. Custom props remain typed
+on the returned component:
+
+```tsx
+export const FirstName = schema.createComponent.forField({
+  step: "step1",
+  field: "firstName",
+  render(field, props: { placeholder?: string }) {
+    return (
+      <Input
+        value={field.defaultValue}
+        placeholder={props.placeholder}
+        onChange={(event) => field.onInputChange(event.target.value)}
+      />
+    );
+  },
+});
+
+export const StepFirstName =
+  schema.stepSchema.value.step1.createComponent.forField({
+    field: "firstName",
+    render: (field) => <Input value={field.defaultValue} />,
+  });
+```
+
 ### 3. Create a "Step Layout"
 
 ```tsx

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ export const StepFirstName =
     field: "firstName",
     render: (field) => <Input value={field.defaultValue} />,
   });
+
+// `name` and `children` are owned by forField. Remaining Field props and custom props
+// are accepted by the generated component.
+<FirstName placeholder="Your name" suspend={false} />;
 ```
 
 ### 3. Create a "Step Layout"

--- a/examples/react-basic/src/components/ui/multi-step-form/steps.tsx
+++ b/examples/react-basic/src/components/ui/multi-step-form/steps.tsx
@@ -9,8 +9,8 @@ import {
   SelectValue,
 } from '../select';
 
-export const Step1 = schema.stepSchema.value.step1.createComponent(
-  function Step1({ ctx, Form, Field: FieldComponent }) {
+export const Step1 = schema.stepSchema.value.step1.createComponent({
+  render: function Step1({ ctx, Form, Field: FieldComponent }) {
     const { title } = ctx.step1;
 
     return (
@@ -59,11 +59,11 @@ export const Step1 = schema.stepSchema.value.step1.createComponent(
         </FieldSet>
       </Form>
     );
-  }
-);
+  },
+});
 
-export const Step2 = schema.stepSchema.value.step2.createComponent(
-  function Step2({ Field: FieldComponent, Form, ctx }) {
+export const Step2 = schema.stepSchema.value.step2.createComponent({
+  render: function Step2({ Field: FieldComponent, Form, ctx }) {
     return (
       <Form targetStep='step2' title={ctx.step2.title}>
         <FieldSet>
@@ -117,11 +117,11 @@ export const Step2 = schema.stepSchema.value.step2.createComponent(
         </FieldSet>
       </Form>
     );
-  }
-);
+  },
+});
 
-export const Step3 = schema.stepSchema.value.step3.createComponent(
-  function Step3({ Field: FieldComponent, Form, ctx, Selector }) {
+export const Step3 = schema.stepSchema.value.step3.createComponent({
+  render: function Step3({ Field: FieldComponent, Form, ctx, Selector }) {
     return (
       <Form targetStep='step3' title={ctx.step3.title}>
         <FieldSet>
@@ -274,5 +274,5 @@ export const Step3 = schema.stepSchema.value.step3.createComponent(
         </FieldSet>
       </Form>
     );
-  }
-);
+  },
+});

--- a/packages/core/docs/instances-and-storage.mdx
+++ b/packages/core/docs/instances-and-storage.mdx
@@ -1,13 +1,13 @@
 ---
 title: Instances, storage & field metadata
 description: "defineMultiStepForm: named instances, per-instance storage, shared createHelperFn, withOverrides, field metadata, and step isComplete."
-package: '@jfdevelops/multi-step-form-core'
+package: "@jfdevelops/multi-step-form-core"
 category: guide
 status: beta
 order: 2
 ---
 
-import { defineMultiStepForm } from '@jfdevelops/multi-step-form-core';
+import { defineMultiStepForm } from "@jfdevelops/multi-step-form-core";
 
 # Instances, storage & field metadata (beta)
 
@@ -34,33 +34,51 @@ touch storage at all.
 
 ## 1. Instances & storage
 
+The definition itself retains the full schema surface, so it can be used directly wherever the
+old single-schema factory was used. Its declared-only `stepNumbers` property exposes the exact
+step union without adding a runtime property:
+
+```ts
+const bookingDefinition = defineMultiStepForm({
+  steps: {
+    step1: { title: "Contact", fields: { email: { defaultValue: "" } } },
+  },
+});
+
+type BookingStep = typeof bookingDefinition.stepNumbers; // 'step1'
+bookingDefinition.stepSchema.value.step1.fields.email.defaultValue;
+```
+
+Calling `.configure()` builds an instance factory from the same shape. The definition and every
+created instance own independent state.
+
 `instances` declares the named, independent copies of the form the factory can create. Each
 instance has its own in-memory state, its own override-resolution state, and (optionally) its own
 storage backend — updates on one instance never leak into another.
 
 ```ts
 const createBookingForm = defineMultiStepForm({
-  steps: { /* ... */ },
-  instances: ['admin', 'client'], // omit `instances` for a single default instance
+  steps: {/* ... */},
+  instances: ["admin", "client"], // omit `instances` for a single default instance
 }).configure({
   storage: {
     // a single string shares one key across every configured instance;
     // a record resolves a different key per instance
-    key: { client: 'booking:client', admin: 'booking:admin' },
+    key: { client: "booking:client", admin: "booking:admin" },
     // only instances listed here ever read/write storage — everyone else is memory-only
-    configure: { instances: ['client'] },
+    configure: { instances: ["client"] },
   },
   update: {
     // optional extra gate on top of storage allocation. Accepts a boolean or a
     // `(instance) => boolean` function. Defaults to `true` when omitted — so an
     // instance persists whenever it has storage allocated. When provided, both this
     // gate AND `storage.configure.instances` must agree for updates to persist.
-    updateStorage: (instance) => instance === 'client',
+    updateStorage: (instance) => instance === "client",
   },
 });
 
-const clientForm = createBookingForm({ instance: 'client' }); // persists to "booking:client"
-const adminForm = createBookingForm({ instance: 'admin' }); // memory-only, never touches storage
+const clientForm = createBookingForm({ instance: "client" }); // persists to "booking:client"
+const adminForm = createBookingForm({ instance: "admin" }); // memory-only, never touches storage
 ```
 
 `.configure()` also accepts `nameTransformCasing` — the default casing used to derive a field's
@@ -69,10 +87,12 @@ const adminForm = createBookingForm({ instance: 'admin' }); // memory-only, neve
 per-definition default applied when each instance is constructed:
 
 ```ts
-defineMultiStepForm({ steps: { /* ... */ } }).configure({ nameTransformCasing: 'camel' });
+defineMultiStepForm({ steps: {/* ... */} }).configure({
+  nameTransformCasing: "camel",
+});
 ```
 
-Calling the factory again with the same `instance` name returns the *same* instance (it doesn't
+Calling the factory again with the same `instance` name returns the _same_ instance (it doesn't
 reset state); calling it also marks that instance "active" for shared helper dispatch (see below).
 Calling with an instance name that wasn't declared in `instances` throws `InvalidInstanceError`.
 
@@ -84,14 +104,15 @@ currently active, so `client` and `admin` reuse the exact same update logic:
 ```ts
 const addService = createBookingForm.step2.createHelperFn(
   { validator: addServiceParams },
-  ({ data, update }) => update.step2({ fields: 'all', updater: { service: data.service } }),
+  ({ data, update }) =>
+    update.step2({ fields: "all", updater: { service: data.service } }),
 );
 
-createBookingForm({ instance: 'client' }); // marks "client" active
-addService({ data: { service: 'Haircut' } }); // updates the client instance
+createBookingForm({ instance: "client" }); // marks "client" active
+addService({ data: { service: "Haircut" } }); // updates the client instance
 
-createBookingForm({ instance: 'admin' }); // marks "admin" active
-addService({ data: { service: 'Color' } }); // updates the admin instance instead
+createBookingForm({ instance: "admin" }); // marks "admin" active
+addService({ data: { service: "Color" } }); // updates the admin instance instead
 ```
 
 Calling a shared helper before any instance has been created throws `NoActiveInstanceError` with a
@@ -105,12 +126,12 @@ Overrides live on the instance, not the shared step config, so client and admin 
 defaults from the exact same field definitions:
 
 ```ts
-const publicForm = createBookingForm({ instance: 'client' }).withOverrides({
+const publicForm = createBookingForm({ instance: "client" }).withOverrides({
   step1: async () => ({ firstName: await currentUser.firstName }),
 });
 
-const adminForm = createBookingForm({ instance: 'admin' }).withOverrides({
-  step3: async () => ({ date: searchParams.get('date') ?? '' }),
+const adminForm = createBookingForm({ instance: "admin" }).withOverrides({
+  step3: async () => ({ date: searchParams.get("date") ?? "" }),
 });
 ```
 
@@ -148,12 +169,12 @@ step1: {
 },
 ```
 
-Read it back via the bound per-step method or the schema-level helper (both reflect the *current*
+Read it back via the bound per-step method or the schema-level helper (both reflect the _current_
 field values, live):
 
 ```ts
 instance.stepSchema.value.step1.isComplete(); // bound, no args
-instance.stepSchema.isStepComplete('step1'); // equivalent
+instance.stepSchema.isStepComplete("step1"); // equivalent
 ```
 
 A step with no `isComplete` configured is always considered complete.
@@ -163,23 +184,23 @@ A step with no `isComplete` configured is always considered complete.
 ```ts
 import type {
   DefineMultiStepFormOptions, // the { steps, instances? } shape defineMultiStepForm accepts
-  InstanceName,               // InstanceName<['admin','client']> = 'admin' | 'client'
-  StorageKey,                 // string | Record<InstanceName, string>
-  WithOverridesMap,           // the object shape .withOverrides() accepts, keyed by step
-  MultiStepFormFactory,       // the callable + step-helper shape .configure() returns
-} from '@jfdevelops/multi-step-form-core';
+  InstanceName, // InstanceName<['admin','client']> = 'admin' | 'client'
+  StorageKey, // string | Record<InstanceName, string>
+  WithOverridesMap, // the object shape .withOverrides() accepts, keyed by step
+  MultiStepFormFactory, // the callable + step-helper shape .configure() returns
+} from "@jfdevelops/multi-step-form-core";
 
 // A form with no `instances` declared has a single, always-available "default" instance:
-const createForm = defineMultiStepForm({ steps: { /* ... */ } }).configure();
+const createForm = defineMultiStepForm({ steps: {/* ... */} }).configure();
 createForm(); // no args needed
 createForm().instanceName; // 'default'
 
 // A form with `instances` declared requires `{ instance }` on every call:
 const createBookingForm = defineMultiStepForm({
-  steps: { /* ... */ },
-  instances: ['admin', 'client'],
+  steps: {/* ... */},
+  instances: ["admin", "client"],
 }).configure();
-createBookingForm({ instance: 'client' }); // ok
+createBookingForm({ instance: "client" }); // ok
 // @ts-expect-error "instance" is required once `instances` is declared
 createBookingForm();
 ```

--- a/packages/core/src/define.ts
+++ b/packages/core/src/define.ts
@@ -22,8 +22,6 @@ import type { CasingType, DefaultCasing, Updater } from '@/utils';
 export type DefaultInstanceName = typeof DEFAULT_INSTANCE_NAME;
 export const DEFAULT_INSTANCE_NAME = 'default';
 
-
-
 export type InstanceName<TInstances extends readonly string[] | undefined> =
   TInstances extends readonly string[]
     ? TInstances[number]
@@ -53,8 +51,7 @@ export type DefineMultiStepFormOptions<
  * resolved per instance (a `Record` of instance name to key).
  */
 export type StorageKey<TInstance extends string> =
-  | string
-  | Record<TInstance, string>;
+  string | Record<TInstance, string>;
 
 export interface ConfigureStorageConfig<TInstance extends string> {
   /**
@@ -105,9 +102,9 @@ export type ConfigureOptions<
 };
 
 export type WithOverridesMap<TSteps extends StepConfig> = Partial<{
-  [key in keyof TSteps as string extends key
-    ? never
-    : key]: TSteps[key] extends AnyConfig ? StepOverrides<TSteps[key]> : never;
+  [
+    key in keyof TSteps as string extends key ? never : key
+  ]: TSteps[key] extends AnyConfig ? StepOverrides<TSteps[key]> : never;
 }>;
 
 /**
@@ -331,7 +328,9 @@ function resolveStorageConfig<
   const key =
     typeof storage!.key === 'string'
       ? storage!.key
-      : (storage!.key as Record<InstanceName<TInstances>, string>)[instanceName];
+      : (storage!.key as Record<InstanceName<TInstances>, string>)[
+          instanceName
+        ];
 
   InvalidInstanceError.invariant(typeof key === 'string' && key.length > 0, {
     reason: `No storage key was found for instance "${instanceName}". Provide a "storage.key" string or a record containing a key for this instance.`,
@@ -375,7 +374,9 @@ function createFactory<
       declaredInstances as TInstances,
       configureOptions,
     );
-    const instance = new MultiStepFormInstanceImpl<DefineConfig<TSteps, TCasing>>({
+    const instance = new MultiStepFormInstanceImpl<
+      DefineConfig<TSteps, TCasing>
+    >({
       steps: steps as DefineConfig<TSteps, TCasing>['steps'],
       nameTransformCasing,
       storageConfig,
@@ -390,8 +391,7 @@ function createFactory<
 
   function factory(options?: { instance?: InstanceName<TInstances> }) {
     const instanceName =
-      options?.instance ??
-      (DEFAULT_INSTANCE_NAME as InstanceName<TInstances>);
+      options?.instance ?? (DEFAULT_INSTANCE_NAME as InstanceName<TInstances>);
 
     if (declaredInstances) {
       InvalidInstanceError.invariant(declaredInstances.includes(instanceName), {
@@ -466,10 +466,14 @@ function createFactory<
 export class MultiStepFormDefinition<
   const TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined = undefined,
-> {
+> extends MultiStepFormSchema<DefineConfig<TSteps, DefaultCasing>> {
   constructor(
     private readonly config: DefineMultiStepFormOptions<TSteps, TInstances>,
-  ) {}
+  ) {
+    // The definition keeps the complete legacy schema surface for immediate use, while
+    // `configure()` creates separate stateful instances from the same immutable shape.
+    super({ steps: config.steps } as DefineConfig<TSteps, DefaultCasing>);
+  }
 
   /**
    * Configures storage and update-persistence behavior for this definition's instances.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -7,12 +7,19 @@ import {
   type BaseStorageConfig,
 } from './storage.js';
 import { Subscribable } from './subscribable.js';
-import type { instantiateSteps } from './steps/steps.js';
+import type { instantiateSteps, StepNumbers } from './steps/steps.js';
 
 export class MultiStepFormSchema<
   const def extends StepSchema.Config,
   value extends instantiateSteps<def> = instantiateSteps<def>,
 > extends Subscribable<MultiStepFormStepSchema.Listener<def, value>> {
+  /**
+   * The concrete step-name union for this schema. This declaration is type-only and does not
+   * create a runtime property.
+   *
+   * @example `type Step = typeof schema.stepNumbers`
+   */
+  declare readonly stepNumbers: StepNumbers<def['steps']>;
   readonly defaultNameTransformationCasing: def['nameTransformCasing'];
   readonly stepSchema: MultiStepFormStepSchema<def, value>;
   storage: MultiStepFormStorage<value, StepSchema.inferStorageKey<def>>;

--- a/packages/core/test/define.test.ts
+++ b/packages/core/test/define.test.ts
@@ -115,6 +115,38 @@ function createBookingDefinition() {
   });
 }
 
+describe('defineMultiStepForm: definition schema surface', () => {
+  it('exposes the schema and a type-only exact step union', () => {
+    const definition = createBookingDefinition();
+
+    type Step = typeof definition.stepNumbers;
+
+    expectTypeOf<Step>().toEqualTypeOf<'step1' | 'step2'>();
+    expect(definition.stepSchema.value.step1.title).toBe('Step 1');
+    expect('stepNumbers' in definition).toBe(false);
+  });
+
+  it('keeps definition and configured instance state independent', () => {
+    const definition = createBookingDefinition();
+    const createForm = definition.configure();
+    const client = createForm({ instance: 'client' });
+
+    definition.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Definition',
+    });
+    client.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Client',
+    });
+
+    expect(definition.stepSchema.getValue('step1', 'firstName')).toBe(
+      'Definition',
+    );
+    expect(client.stepSchema.getValue('step1', 'firstName')).toBe('Client');
+  });
+});
+
 describe('defineMultiStepForm: instances', () => {
   it('creates independent state per named instance', () => {
     const createForm = createBookingDefinition().configure();

--- a/packages/react/docs/instances-and-storage.mdx
+++ b/packages/react/docs/instances-and-storage.mdx
@@ -1,13 +1,13 @@
 ---
 title: Instances, storage & the builder order
 description: "defineMultiStepForm in React: the withOverrides -> withForm -> withContext builder order and wiring the active instance in a React tree."
-package: '@jfdevelops/react-multi-step-form'
+package: "@jfdevelops/react-multi-step-form"
 category: guide
 status: beta
 order: 2
 ---
 
-import { defineMultiStepForm } from '@jfdevelops/react-multi-step-form';
+import { defineMultiStepForm } from "@jfdevelops/react-multi-step-form";
 
 # Instances, storage & the builder order (beta)
 
@@ -15,6 +15,20 @@ import { defineMultiStepForm } from '@jfdevelops/react-multi-step-form';
 package's factory (named instances, per-instance storage, shared `createHelperFn`,
 `withOverrides`) while producing full React `MultiStepFormSchema` instances with `.withForm()`,
 `.withContext()`, and `createComponent` available on every instance.
+
+The definition returned before `.configure()` is also a complete React schema. It exposes
+`stepSchema`, `withForm`, `withContext`, and `createComponent`, plus a declared-only exact step
+union:
+
+```tsx
+const bookingDefinition = defineMultiStepForm({
+  steps: {
+    step1: { title: "Contact", fields: { email: { defaultValue: "" } } },
+  },
+});
+
+type BookingStep = typeof bookingDefinition.stepNumbers; // 'step1'
+```
 
 > Upgrading from alpha? See [`migration.mdx`](./migration.mdx) first.
 >
@@ -31,15 +45,17 @@ An instance returned by the factory is a full `MultiStepFormSchema`, so `.withOv
 with the existing `.withForm()` / `.withContext()`:
 
 ```tsx
-import { defineMultiStepForm } from '@jfdevelops/react-multi-step-form';
+import { defineMultiStepForm } from "@jfdevelops/react-multi-step-form";
 
 const createBookingForm = defineMultiStepForm({
-  steps: { /* ... */ },
-  instances: ['admin', 'client'],
-}).configure({ storage: { key: 'booking', configure: { instances: ['client'] } } });
+  steps: {/* ... */},
+  instances: ["admin", "client"],
+}).configure({
+  storage: { key: "booking", configure: { instances: ["client"] } },
+});
 
-const publicForm = createBookingForm({ instance: 'client' })
-  .withOverrides({ step1: async ({ fields }) => ({ /* ... */ }) })
+const publicForm = createBookingForm({ instance: "client" })
+  .withOverrides({ step1: async ({ fields }) => ({/* ... */}) })
   .withForm({ render: ({ id }, props) => <form id={id} {...props} /> })
   .withContext();
 
@@ -49,10 +65,29 @@ export const { useMultiStepFormData, useCurrentStepData } = publicForm.context;
 `withOverrides` → `withForm` → `withContext` is the supported order; `withOverrides` and
 `withForm`/`withContext` are each optional and can be skipped if you don't need them.
 
+Both instance-level and step-level `createComponent` use a single object API. Targeting one step
+from an instance delegates to that step's component factory, so both render callbacks receive the
+same `Field`, form component, suspense, selector, update/reset, and default-value utilities:
+
+```tsx
+const ContactStep = publicForm.createComponent({
+  stepData: ["step1"],
+  render({ Field, Form, useStep }) {
+    return <Form>{/* ... */}</Form>;
+  },
+});
+
+const SameContactStep = publicForm.stepSchema.value.step1.createComponent({
+  render({ Field, Form, useStep }) {
+    return <Form>{/* ... */}</Form>;
+  },
+});
+```
+
 ## Wiring the active instance
 
 Shared `createHelperFn`s (`createBookingForm.step2.createHelperFn(...)`) dispatch to whichever
-instance is currently *active* — the instance most recently created/used via the factory, or
+instance is currently _active_ — the instance most recently created/used via the factory, or
 whichever `createBookingForm.setActiveInstance(...)` last selected. In a React tree with more than
 one instance (e.g. a public route and an admin route mounted in the same app), build or re-select
 the right instance for that part of the tree before it renders anything that calls shared helpers:
@@ -61,13 +96,13 @@ the right instance for that part of the tree before it renders anything that cal
 function PublicBookingPage() {
   // Marks "client" active for this render. Memoize/hoist this in real usage so it
   // isn't rebuilt on every render — see the core docs for instance reuse semantics.
-  const form = createBookingForm({ instance: 'client' });
+  const form = createBookingForm({ instance: "client" });
 
   return <BookingForm schema={form} />;
 }
 
 function AdminBookingPage() {
-  const form = createBookingForm({ instance: 'admin' });
+  const form = createBookingForm({ instance: "admin" });
 
   return <BookingForm schema={form} />;
 }

--- a/packages/react/docs/instances-and-storage.mdx
+++ b/packages/react/docs/instances-and-storage.mdx
@@ -107,6 +107,9 @@ const InstanceFirstName =
     field: "firstName",
     render: (field) => <input value={field.defaultValue} readOnly />,
   });
+
+// `name` and `children` are fixed internally; Field props and custom props are forwarded.
+<SharedFirstName placeholder="Your name" suspend={false} />;
 ```
 
 The configured-factory version resolves against the active instance and caches a separate bound

--- a/packages/react/docs/instances-and-storage.mdx
+++ b/packages/react/docs/instances-and-storage.mdx
@@ -84,6 +84,35 @@ const SameContactStep = publicForm.stepSchema.value.step1.createComponent({
 });
 ```
 
+Use `createComponent.forField` when a component only represents one field. The schema-level form
+accepts both `step` and `field`; a step-specific factory already knows its step:
+
+```tsx
+const SharedFirstName = createBookingForm.createComponent.forField({
+  step: "step1",
+  field: "firstName",
+  render(field, props: { placeholder?: string }) {
+    return (
+      <input
+        value={field.defaultValue}
+        placeholder={props.placeholder}
+        onChange={(event) => field.onInputChange(event.target.value)}
+      />
+    );
+  },
+});
+
+const InstanceFirstName =
+  publicForm.stepSchema.value.step1.createComponent.forField({
+    field: "firstName",
+    render: (field) => <input value={field.defaultValue} readOnly />,
+  });
+```
+
+The configured-factory version resolves against the active instance and caches a separate bound
+component per instance. This lets the same component definition be reused without sharing form
+state or subscriptions.
+
 ## Wiring the active instance
 
 Shared `createHelperFn`s (`createBookingForm.step2.createHelperFn(...)`) dispatch to whichever

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -16,7 +16,9 @@ import {
   type WithOverridesMap,
 } from '@jfdevelops/multi-step-form-core';
 import { MultiStepFormSchema } from './schema';
+import type { CreateComponentFn } from './step-schema';
 import type { instantiateReactSteps } from './steps';
+import { createElement, type ReactNode } from 'react';
 
 /**
  * The resolved instantiated value shape for a form definition's steps, independent of any
@@ -213,7 +215,16 @@ export type MultiStepFormReactFactoryStepProperties<TSteps extends StepConfig> =
 export type MultiStepFormReactFactoryBase<
   TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined,
+  TCasing extends CasingType,
 > = MultiStepFormReactFactoryStepProperties<TSteps> & {
+  /** Creates reusable field components that resolve against the active instance. */
+  createComponent: Pick<
+    CreateComponentFn<
+      DefineConfig<TSteps, TCasing>,
+      instantiateReactSteps<DefineConfig<TSteps, TCasing>>
+    >,
+    'forField'
+  >;
   /**
    * Explicitly sets the active instance (the instance shared `createHelperFn`s dispatch to).
    *
@@ -231,7 +242,7 @@ export type MultiStepFormReactFactory<
   TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined,
   TCasing extends CasingType = CasingType,
-> = MultiStepFormReactFactoryBase<TSteps, TInstances> &
+> = MultiStepFormReactFactoryBase<TSteps, TInstances, TCasing> &
   (<TInstance extends InstanceName<TInstances>>(
     ...args: MultiStepFormReactFactoryCallOptions<TInstances, TInstance>
   ) => MultiStepFormReactInstance<DefineConfig<TSteps, TCasing>>);
@@ -349,7 +360,46 @@ function createReactFactory<
     ]),
   );
 
+  const sharedCreateComponent = {
+    forField(componentConfig: {
+      step: string;
+      field: string;
+      render: (field: unknown, props: unknown) => ReactNode;
+    }) {
+      // Each active instance gets its own bound component. Caching preserves component identity
+      // and subscriptions when the shared component is reused across independently stored forms.
+      const components = new WeakMap<object, (props?: unknown) => ReactNode>();
+
+      return (props?: unknown) => {
+        const active = getActiveInstance();
+        let Component = components.get(active);
+
+        if (!Component) {
+          const step = (active.stepSchema.value as Record<string, unknown>)[
+            componentConfig.step
+          ] as {
+            createComponent: {
+              forField: (config: {
+                field: string;
+                render: (field: unknown, props: unknown) => ReactNode;
+              }) => (props?: unknown) => ReactNode;
+            };
+          };
+
+          Component = step.createComponent.forField({
+            field: componentConfig.field,
+            render: componentConfig.render,
+          });
+          components.set(active, Component);
+        }
+
+        return createElement(Component as never, props as never);
+      };
+    },
+  };
+
   return Object.assign(factory, stepHelpers, {
+    createComponent: sharedCreateComponent,
     setActiveInstance(instanceName: InstanceName<TInstances>) {
       InvalidInstanceError.invariant(registry.has(instanceName), {
         reason: `"${instanceName}" has not been created yet. Call the factory with this instance first.`,

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -22,9 +22,10 @@ import type { instantiateReactSteps } from './steps';
  * The resolved instantiated value shape for a form definition's steps, independent of any
  * particular instance.
  */
-export type DefineReactValue<TSteps extends StepConfig> = instantiateReactSteps<{
-  steps: TSteps;
-}>;
+export type DefineReactValue<TSteps extends StepConfig> =
+  instantiateReactSteps<{
+    steps: TSteps;
+  }>;
 
 export interface MultiStepFormReactInstance<
   def extends DefineConfig,
@@ -76,25 +77,33 @@ function attachInstance<
     onRebuild: (next: MultiStepFormReactInstance<def>) => void;
   },
 ): MultiStepFormReactInstance<def> {
-  const { rawSteps, nameTransformCasing, storageConfig, instanceName, onRebuild } = options;
+  const {
+    rawSteps,
+    nameTransformCasing,
+    storageConfig,
+    instanceName,
+    onRebuild,
+  } = options;
 
   return Object.assign(instance, {
     instanceName,
     withOverrides(overrides: WithOverridesMap<def['steps']>) {
       const mergedSteps = Object.fromEntries(
-        Object.entries(rawSteps as Record<string, object>).map(([key, stepConfig]) => {
-          const override = (overrides as Record<string, unknown>)[key];
+        Object.entries(rawSteps as Record<string, object>).map(
+          ([key, stepConfig]) => {
+            const override = (overrides as Record<string, unknown>)[key];
 
-          return [
-            key,
-            override
-              ? {
-                  ...stepConfig,
-                  overrides: override,
-                }
-              : stepConfig,
-          ];
-        }),
+            return [
+              key,
+              override
+                ? {
+                    ...stepConfig,
+                    overrides: override,
+                  }
+                : stepConfig,
+            ];
+          },
+        ),
       ) as def['steps'];
 
       const next = attachInstance<def, TInstance>(
@@ -132,7 +141,8 @@ function resolveStorageConfig<
     storage?.configure?.instances ??
     (declaredInstances as readonly InstanceName<TInstances>[] | undefined) ??
     ([DEFAULT_INSTANCE_NAME] as unknown as readonly InstanceName<TInstances>[]);
-  const hasStorage = Boolean(storage) && configuredInstances.includes(instanceName);
+  const hasStorage =
+    Boolean(storage) && configuredInstances.includes(instanceName);
   const updateStorage = update?.updateStorage;
   const passesUpdateGate =
     updateStorage === undefined
@@ -152,7 +162,9 @@ function resolveStorageConfig<
   const key =
     typeof storage!.key === 'string'
       ? storage!.key
-      : (storage!.key as Record<InstanceName<TInstances>, string>)[instanceName];
+      : (storage!.key as Record<InstanceName<TInstances>, string>)[
+          instanceName
+        ];
 
   InvalidInstanceError.invariant(typeof key === 'string' && key.length > 0, {
     reason: `No storage key was found for instance "${instanceName}". Provide a "storage.key" string or a record containing a key for this instance.`,
@@ -191,12 +203,12 @@ export interface MultiStepFormReactFactoryStepFunctions<
   createHelperFn: StepSpecificHelperFn<DefineReactValue<TSteps>, key>;
 }
 
-export type MultiStepFormReactFactoryStepProperties<TSteps extends StepConfig> = {
-  [key in StepNumbers<DefineReactValue<TSteps>>]: MultiStepFormReactFactoryStepFunctions<
-    TSteps,
-    key
-  >;
-};
+export type MultiStepFormReactFactoryStepProperties<TSteps extends StepConfig> =
+  {
+    [
+      key in StepNumbers<DefineReactValue<TSteps>>
+    ]: MultiStepFormReactFactoryStepFunctions<TSteps, key>;
+  };
 
 export type MultiStepFormReactFactoryBase<
   TSteps extends StepConfig,
@@ -279,8 +291,7 @@ function createReactFactory<
 
   function factory(options?: { instance?: InstanceName<TInstances> }) {
     const instanceName =
-      options?.instance ??
-      (DEFAULT_INSTANCE_NAME as InstanceName<TInstances>);
+      options?.instance ?? (DEFAULT_INSTANCE_NAME as InstanceName<TInstances>);
 
     if (declaredInstances) {
       InvalidInstanceError.invariant(declaredInstances.includes(instanceName), {
@@ -322,9 +333,14 @@ function createReactFactory<
         createHelperFn: (optionsOrFn: unknown, fn?: unknown) => {
           return (input?: unknown) => {
             const active = getActiveInstance();
-            const stepValue = (active.stepSchema.value as Record<string, unknown>)[
-              stepKey
-            ] as { createHelperFn: (a: unknown, b?: unknown) => (i?: unknown) => unknown };
+            const stepValue = (
+              active.stepSchema.value as Record<string, unknown>
+            )[stepKey] as {
+              createHelperFn: (
+                a: unknown,
+                b?: unknown,
+              ) => (i?: unknown) => unknown;
+            };
 
             return stepValue.createHelperFn(optionsOrFn, fn)(input);
           };
@@ -350,10 +366,14 @@ function createReactFactory<
 export class MultiStepFormReactDefinition<
   const TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined = undefined,
-> {
+> extends MultiStepFormSchema<DefineConfig<TSteps, DefaultCasing>> {
   constructor(
     private readonly config: DefineMultiStepFormOptions<TSteps, TInstances>,
-  ) {}
+  ) {
+    // The definition remains a fully usable React schema, while `configure()` creates
+    // independent instances that reuse only its declared shape.
+    super({ steps: config.steps } as DefineConfig<TSteps, DefaultCasing>);
+  }
 
   /**
    * Configures storage and update-persistence behavior for this definition's instances.
@@ -364,12 +384,15 @@ export class MultiStepFormReactDefinition<
    * @returns A callable factory used to create/retrieve named instances.
    */
   configure<const TCasing extends CasingType = DefaultCasing>(
-    configureOptions: ConfigureOptions<TInstances, TCasing> = {} as ConfigureOptions<
+    configureOptions: ConfigureOptions<
       TInstances,
       TCasing
-    >,
+    > = {} as ConfigureOptions<TInstances, TCasing>,
   ): MultiStepFormReactFactory<TSteps, TInstances, TCasing> {
-    return createReactFactory<TSteps, TInstances, TCasing>(this.config, configureOptions);
+    return createReactFactory<TSteps, TInstances, TCasing>(
+      this.config,
+      configureOptions,
+    );
   }
 }
 

--- a/packages/react/src/field.tsx
+++ b/packages/react/src/field.tsx
@@ -8,7 +8,7 @@ import type {
   resolveDeepFieldPath,
   StepNumbers,
   UpdateFn,
-  Updater
+  Updater,
 } from '@jfdevelops/multi-step-form-core';
 import type { ReactNode } from 'react';
 import { Suspense, memo, useSyncExternalStore } from 'react';
@@ -32,59 +32,64 @@ export namespace field {
   }> &
     UpdateFn.DebugOptions;
 
-  type normalizeChildrenConfig<TConfig, TValue> =
-    TConfig extends { defaultValue: unknown }
-      ? Override<TConfig, 'defaultValue', TValue> extends infer resolvedConfig
-        ? resolvedConfig extends { label: false }
-          ? Omit<resolvedConfig, 'label'>
-          : resolvedConfig
-        : never
-      : never;
+  type normalizeChildrenConfig<TConfig, TValue> = TConfig extends {
+    defaultValue: unknown;
+  }
+    ? Override<TConfig, 'defaultValue', TValue> extends infer resolvedConfig
+      ? resolvedConfig extends { label: false }
+        ? Omit<resolvedConfig, 'label'>
+        : resolvedConfig
+      : never
+    : never;
 
   export type childrenProps<
     steps extends instantiateSteps,
     field extends getDeepFields<steps, targetStep>,
     targetStep extends StepNumbers<steps> = StepNumbers<steps>,
     value extends resolveDeepFieldPath<steps, targetStep, field> =
-    resolveDeepFieldPath<steps, targetStep, field>,
-    TConfig extends getFieldConfig<steps, targetStep, field> =
-    getFieldConfig<steps, targetStep, field>,
+      resolveDeepFieldPath<steps, targetStep, field>,
+    TConfig extends getFieldConfig<steps, targetStep, field> = getFieldConfig<
+      steps,
+      targetStep,
+      field
+    >,
   > = sharedProps<field> &
     (TConfig extends { defaultValue: unknown }
       ? normalizeChildrenConfig<TConfig, value>
       : {
-        defaultValue: `An unknown error occurred while getting the "defaultValue" for ${field}`;
-      }) & {
-        /**
-         * A useful wrapper around `update` to update the specific field.
-         * @param value The new value for the field.
-         * @param options The options for the update operation.
-         */
-        onInputChange: <
-          strict extends boolean = true,
-          partial extends boolean = false,
-        >(
-          value: Updater<
-            UpdateFn.resolvedUpdaterReturnType<
-              value,
-              { strict: strict; partial: partial },
-              {}
-            >
-          >,
-          options?: onInputChangeOptions<strict, partial>
-        ) => void;
-        /**
-         * Resets the field's value to the original value that was
-         * defined in the config.
-         */
-        reset: (options?: UpdateFn.DebugOptions) => void;
-      };
+          defaultValue: `An unknown error occurred while getting the "defaultValue" for ${field}`;
+        }) & {
+      /**
+       * A useful wrapper around `update` to update the specific field.
+       * @param value The new value for the field.
+       * @param options The options for the update operation.
+       */
+      onInputChange: <
+        strict extends boolean = true,
+        partial extends boolean = false,
+      >(
+        value: Updater<
+          UpdateFn.resolvedUpdaterReturnType<
+            value,
+            { strict: strict; partial: partial },
+            {}
+          >
+        >,
+        options?: onInputChangeOptions<strict, partial>,
+      ) => void;
+      /**
+       * Resets the field's value to the original value that was
+       * defined in the config.
+       */
+      reset: (options?: UpdateFn.DebugOptions) => void;
+    };
 
   export type childrenPropsWithSelected<
     steps extends instantiateSteps,
-    field extends getDeepFields<steps, StepNumbers<steps>>,
+    targetStep extends StepNumbers<steps>,
+    field extends getDeepFields<steps, targetStep>,
     TSelected,
-  > = childrenProps<steps, field> & {
+  > = childrenProps<steps, field, targetStep> & {
     selected: {
       /**
        * The result of the `selectorFn`.
@@ -92,9 +97,14 @@ export namespace field {
       value: TSelected;
     };
   };
-  export type props<
-    step extends instantiateSteps,
-    field extends getDeepFields<step, StepNumbers<step>>,
+  /**
+   * Field props with an explicit step. Keeping the step separate prevents fields with the same
+   * name on different steps from widening each other's value and metadata types.
+   */
+  export type boundProps<
+    steps extends instantiateSteps,
+    targetStep extends StepNumbers<steps>,
+    field extends getDeepFields<steps, targetStep>,
     selected,
   > = sharedProps<field> &
     (
@@ -107,31 +117,33 @@ export namespace field {
           fallback: ReactNode;
         }
     ) & {
-      selectorFn?: SelectorFn<step, selected>;
+      selectorFn?: SelectorFn<steps, selected>;
       children: (
         props: [selected] extends [never]
-          ? childrenProps<step, field>
-          : childrenPropsWithSelected<step, field, selected>
+          ? childrenProps<steps, field, targetStep>
+          : childrenPropsWithSelected<steps, targetStep, field, selected>,
       ) => ReactNode;
     };
+
+  export type props<
+    step extends instantiateSteps,
+    field extends getDeepFields<step, StepNumbers<step>>,
+    selected,
+  > = boundProps<step, StepNumbers<step>, field, selected>;
   export type component<steps extends instantiateSteps> = <
     field extends getDeepFields<steps, StepNumbers<steps>>,
     selected = never,
   >(
-    props: props<steps, field, selected>
+    props: props<steps, field, selected>,
   ) => ReactNode;
 
   export type createOptions<step extends instantiateSteps> = {
-    propsCreator: <
-        field extends getDeepFields<step, StepNumbers<step>>,
-    >(
-      name: field
+    propsCreator: <field extends getDeepFields<step, StepNumbers<step>>>(
+      name: field,
     ) => field.childrenProps<step, field>;
     subscribe?: (listener: () => void) => () => void;
-    getValue?: <
-      field extends getDeepFields<step, StepNumbers<step>>,
-    >(
-      name: field
+    getValue?: <field extends getDeepFields<step, StepNumbers<step>>>(
+      name: field,
     ) => resolveDeepFieldPath<step, StepNumbers<step>, field>;
     selectorCtx: () => Expand<HelperFn.buildCtx<step, [StepNumbers<step>]>>;
     suspendStep?: () => void;
@@ -145,9 +157,10 @@ export namespace field {
    * @returns
    */
   export function create<step extends instantiateSteps>(
-    options: createOptions<step>
+    options: createOptions<step>,
   ) {
-    const { propsCreator, subscribe, getValue, selectorCtx, suspendStep } = options;
+    const { propsCreator, subscribe, getValue, selectorCtx, suspendStep } =
+      options;
 
     function FieldResolutionGate({ children }: { children: ReactNode }) {
       suspendStep?.();
@@ -159,14 +172,14 @@ export namespace field {
       const { name, children, selectorFn } = props;
 
       // Always call the hook, but use no-op functions if subscribe/getValue aren't provided
-      const subscribeFn = subscribe || (() => () => { });
+      const subscribeFn = subscribe || (() => () => {});
       const getValueFn = getValue || (() => undefined);
 
       // Subscribe to changes to trigger rerenders
       const currentValue = useSyncExternalStore(
         subscribeFn,
         () => getValueFn(name),
-        () => getValueFn(name)
+        () => getValueFn(name),
       );
 
       let createdProps = propsCreator(name);

--- a/packages/react/src/form-config.tsx
+++ b/packages/react/src/form-config.tsx
@@ -22,11 +22,13 @@ export namespace MultiStepFormSchemaConfig {
   export type formEnabledFor<value extends instantiateReactSteps> =
     HelperFnChosenSteps.main<value, StepNumbers<value>>;
   type strippedResolvedSteps<value extends instantiateReactSteps> = {
-    [key in keyof value as key extends string
-      ? `step${number}` extends key
-        ? never
+    [
+      key in keyof value as key extends string
+        ? `step${number}` extends key
+          ? never
+          : key
         : key
-      : key]: Expand<
+    ]: Expand<
       Omit<
         value[key],
         'createComponent' | 'createHelperFn' | 'update' | 'reset'
@@ -53,23 +55,26 @@ export namespace MultiStepFormSchemaConfig {
     }
       ? enabledForSteps // Case: `enabledForSteps` isn't provided (default behavior)
       : def extends { form: infer form }
-      ? form extends { enabledForSteps: infer enabledForSteps }
-        ? enabledForSteps // Case: `enabledForSteps` is provided in the form config
-        : never
-      : never;
+        ? form extends { enabledForSteps: infer enabledForSteps }
+          ? enabledForSteps // Case: `enabledForSteps` is provided in the form config
+          : never
+        : never;
     export type resolveType<
       def extends StepSchema.Config,
       steps extends instantiateReactSteps<def>,
-      value = instantiateFormConfig<def>
-    > = get<value> extends defaultEnabledFor
-      ? 'all'
-      : get<value> extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>
-      ? 'tuple'
-      : get<value> extends HelperFnChosenSteps.objectNotation<
-          StepNumbers<steps>
-        >
-      ? 'object'
-      : never;
+      value = instantiateFormConfig<def>,
+    > =
+      get<value> extends defaultEnabledFor
+        ? 'all'
+        : get<value> extends HelperFnChosenSteps.tupleNotation<
+              StepNumbers<steps>
+            >
+          ? 'tuple'
+          : get<value> extends HelperFnChosenSteps.objectNotation<
+                StepNumbers<steps>
+              >
+            ? 'object'
+            : never;
   }
 
   export type inferFormEnabledForSteps<def> = def extends {
@@ -92,49 +97,50 @@ export namespace MultiStepFormSchemaConfig {
       ? [form] extends [never]
         ? never
         : keyof FormConfig.withoutRender<form> extends never
-        ? Expand<
-            {
-              alias: inferFormAlias<form>;
-              enabledForSteps: inferFormEnabledForSteps<form>;
-            } & inferredFormComponent<form>
-          >
-        : {
-            -readonly [key in keyof FormConfig.withoutRender<form>]: Expand<
+          ? Expand<
               {
-                alias: inferFormAlias<FormConfig.withoutRender<form>>;
-                enabledForSteps: inferFormEnabledForSteps<
-                  FormConfig.withoutRender<form>
-                >;
+                alias: inferFormAlias<form>;
+                enabledForSteps: inferFormEnabledForSteps<form>;
               } & inferredFormComponent<form>
-            >;
-          }[keyof FormConfig.withoutRender<form>]
+            >
+          : {
+              -readonly [key in keyof FormConfig.withoutRender<form>]: Expand<
+                {
+                  alias: inferFormAlias<FormConfig.withoutRender<form>>;
+                  enabledForSteps: inferFormEnabledForSteps<
+                    FormConfig.withoutRender<form>
+                  >;
+                } & inferredFormComponent<form>
+              >;
+            }[keyof FormConfig.withoutRender<form>]
       : {}
     : {};
-  export type getEnabledForSteps<def> = instantiateFormConfig<def> extends {
-    enabledForSteps: infer enabledForSteps;
-  }
-    ? enabledForSteps
-    : def;
+  export type getEnabledForSteps<def> =
+    instantiateFormConfig<def> extends {
+      enabledForSteps: infer enabledForSteps;
+    }
+      ? enabledForSteps
+      : def;
   export type AvailableStepForForm<
     value extends instantiateReactSteps,
-    enabledFor extends formEnabledFor<value>
+    enabledFor extends formEnabledFor<value>,
   > = enabledFor extends defaultEnabledFor
     ? strippedResolvedSteps<value>
     : enabledFor extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>
-    ? enabledFor[number] extends keyof value
-      ? Pick<
-          strippedResolvedSteps<value>,
-          Extract<enabledFor[number], keyof strippedResolvedSteps<value>>
-        >
-      : never
-    : keyof enabledFor extends keyof value
-    ? Expand<
-        Pick<
-          strippedResolvedSteps<value>,
-          Extract<keyof enabledFor, keyof strippedResolvedSteps<value>>
-        >
-      >
-    : never;
+      ? enabledFor[number] extends keyof value
+        ? Pick<
+            strippedResolvedSteps<value>,
+            Extract<enabledFor[number], keyof strippedResolvedSteps<value>>
+          >
+        : never
+      : keyof enabledFor extends keyof value
+        ? Expand<
+            Pick<
+              strippedResolvedSteps<value>,
+              Extract<keyof enabledFor, keyof strippedResolvedSteps<value>>
+            >
+          >
+        : never;
   export type formCtx<alias extends string, props> = {
     [_ in alias]: CreatedMultiStepFormComponent<props>;
   };
@@ -174,7 +180,7 @@ export namespace MultiStepFormSchemaConfig {
     steps extends Record<string, unknown>,
     targetStep extends renderContextStep<steps>,
     props,
-    isDataGuaranteed extends boolean = false
+    isDataGuaranteed extends boolean = false,
   > = {
     targetStep: targetStep;
     isDataGuaranteed?: isDataGuaranteed;
@@ -188,17 +194,17 @@ export namespace MultiStepFormSchemaConfig {
     steps extends Record<string, unknown>,
     targetStep extends renderContextStep<steps>,
     props,
-    hasData extends boolean
+    hasData extends boolean,
   > = {
     data: hasData extends true ? steps[targetStep] : undefined;
     hasData: hasData;
-    renderNoCurrentData: renderCallback<props>;
+    NoCurrentData: renderCallback<props>;
   };
 
   export type getCurrentStepData<steps extends Record<string, unknown>> = <
     targetStep extends renderContextStep<steps>,
     props = undefined,
-    isDataGuaranteed extends boolean = false
+    isDataGuaranteed extends boolean = false,
   >(
     options: getCurrentStepDataOptions<
       steps,
@@ -207,18 +213,14 @@ export namespace MultiStepFormSchemaConfig {
       isDataGuaranteed
     >,
   ) => isDataGuaranteed extends true
-    ? Omit<
-        currentStepDataResult<steps, targetStep, props, true>,
-        'hasData'
-      >
-    :
-        | currentStepDataResult<steps, targetStep, props, true>
-        | currentStepDataResult<steps, targetStep, props, false>;
+    ? Omit<currentStepDataResult<steps, targetStep, props, true>, 'hasData'>
+    : | currentStepDataResult<steps, targetStep, props, true>
+      | currentStepDataResult<steps, targetStep, props, false>;
 
   export type getProgressOptions<
     steps extends Record<string, unknown>,
     targetStep extends renderContextStep<steps>,
-    props
+    props,
   > = {
     targetStep: targetStep;
     totalSteps?: number;
@@ -235,13 +237,13 @@ export namespace MultiStepFormSchemaConfig {
 
   export type getProgress<steps extends Record<string, unknown>> = <
     targetStep extends renderContextStep<steps>,
-    props = undefined
+    props = undefined,
   >(
     options: getProgressOptions<steps, targetStep, props>,
   ) => {
     value: number;
     maxProgressValue: number;
-    renderProgressText: renderCallback<props>;
+    ProgressText: renderCallback<props>;
   };
 
   export type renderContext<steps extends Record<string, unknown>> = {
@@ -258,7 +260,8 @@ export namespace MultiStepFormSchemaConfig {
      */
     getCurrentStepData: getCurrentStepData<steps>;
     /**
-     * Calculates live progress without requiring a hook inside `render`.
+     * Calculates live progress and returns its `ProgressText` component without requiring a
+     * hook inside `render`.
      */
     getProgress: getProgress<steps>;
     /**
@@ -271,12 +274,13 @@ export namespace MultiStepFormSchemaConfig {
     export type withoutRender<def> = Omit<def, 'render'>;
   }
 
-  export type formDefinition<formConfig> = FormConfig.withoutRender<formConfig> & {
-    render: (
-      context: unknown,
-      customProps: inferFormProps<formConfig>,
-    ) => ReactNode;
-  };
+  export type formDefinition<formConfig> =
+    FormConfig.withoutRender<formConfig> & {
+      render: (
+        context: unknown,
+        customProps: inferFormProps<formConfig>,
+      ) => ReactNode;
+    };
 
   /**
    * The configuration options for the `form` option.
@@ -318,11 +322,12 @@ export namespace MultiStepFormSchemaConfig {
      *  }
      * })
      *
-     * const Step1 = schema.stepSchema.step1.createComponent(
-     *  ({ ctx, MyCustomForm }, props: { children: ReactNode }) =>
+     * const Step1 = schema.stepSchema.step1.createComponent({
+     *   render({ ctx, MyCustomForm }, props: { children: ReactNode }) {
      *     // Notice how the form is available with its alias
-     *     <MyCustomFormName>{children}</MyCustomFormName>
-     *  )
+     *     return <MyCustomFormName>{children}</MyCustomFormName>;
+     *   },
+     * })
      * ```
      */
     alias?: string;
@@ -359,12 +364,12 @@ export namespace MultiStepFormSchemaConfig {
      *   form: {
      *    alias: 'MyCustomForm',
      *    render(context, props: CustomProps) {
-     *      const progress = context.getProgress({ targetStep: 'step1' });
+     *      const { ProgressText } = context.getProgress({ targetStep: 'step1' });
      *      return (
      *         <div>
      *          <h1>{props.title}</h1>
      *          <p>{props.description}</p>
-     *          {progress.renderProgressText()}
+     *          <ProgressText />
      *          <form>{props.children}</form>
      *         </div>
      *       );
@@ -403,7 +408,7 @@ export namespace MultiStepFormSchemaConfig {
 
   export function instantiateFormConfig<
     const def extends StepSchema.Config,
-    value extends instantiateReactSteps<def>
+    value extends instantiateReactSteps<def>,
   >(
     getSteps: () => value,
     subscribe: (listener: () => void) => () => void,
@@ -411,7 +416,7 @@ export namespace MultiStepFormSchemaConfig {
   ) {
     return <
       const form extends FormConfig<def, value>,
-      inst = instantiateFormConfig<form>
+      inst = instantiateFormConfig<form>,
     >(
       config: form | undefined,
       defaultId: string,
@@ -475,8 +480,14 @@ export namespace MultiStepFormSchemaConfig {
       });
 
       function Form(customProps: inferFormProps<form>) {
-        const resolvedSteps = useSyncExternalStore(subscribe, getSteps, getSteps);
-        const steps = createRenderSteps(resolvedSteps) as renderContextSteps<value>;
+        const resolvedSteps = useSyncExternalStore(
+          subscribe,
+          getSteps,
+          getSteps,
+        );
+        const steps = createRenderSteps(
+          resolvedSteps,
+        ) as renderContextSteps<value>;
 
         function isStepComplete(targetStep: string) {
           const validSteps = Object.keys(steps);
@@ -515,7 +526,7 @@ export namespace MultiStepFormSchemaConfig {
 
           const data = steps[targetStep as keyof typeof steps];
 
-          function renderNoCurrentData(props?: defaultRenderProps) {
+          function NoCurrentData(props?: defaultRenderProps) {
             if (notFoundMessage) {
               return notFoundMessage({ targetStep }, props as never);
             }
@@ -528,7 +539,7 @@ export namespace MultiStepFormSchemaConfig {
           if (isDataGuaranteed) {
             return {
               data,
-              renderNoCurrentData,
+              NoCurrentData,
             };
           }
 
@@ -536,14 +547,14 @@ export namespace MultiStepFormSchemaConfig {
             return {
               data,
               hasData: true,
-              renderNoCurrentData,
+              NoCurrentData,
             };
           }
 
           return {
             data: undefined,
             hasData: false,
-            renderNoCurrentData,
+            NoCurrentData,
           };
         }
 
@@ -578,7 +589,7 @@ export namespace MultiStepFormSchemaConfig {
           const value =
             (Number.parseInt(currentStep, 10) / totalSteps) * maxProgressValue;
 
-          function renderProgressText(props?: defaultRenderProps) {
+          function ProgressText(props?: defaultRenderProps) {
             if (progressTextTransformer) {
               return progressTextTransformer(
                 { targetStep, maxProgressValue, totalSteps },
@@ -596,19 +607,20 @@ export namespace MultiStepFormSchemaConfig {
           return {
             value,
             maxProgressValue,
-            renderProgressText,
+            ProgressText,
           };
         }
 
         return render(
-          ({
+          {
             id: id ?? defaultId,
-            steps:
-              steps as unknown as renderContext<renderContextSteps<value>>['steps'],
+            steps: steps as unknown as renderContext<
+              renderContextSteps<value>
+            >['steps'],
             getCurrentStepData,
             getProgress,
             isStepComplete,
-          } as unknown as renderContext<renderContextSteps<value>>),
+          } as unknown as renderContext<renderContextSteps<value>>,
           customProps,
         );
       }
@@ -634,7 +646,7 @@ export namespace MultiStepFormSchemaConfig {
   export function isFormAvailable<
     value extends instantiateReactSteps,
     target extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-    enabledFor extends formEnabledFor<value>
+    enabledFor extends formEnabledFor<value>,
   >(target: target, enabledFor: enabledFor) {
     if (Array.isArray(target)) {
       const match = HelperFnChosenSteps.match({
@@ -648,7 +660,7 @@ export namespace MultiStepFormSchemaConfig {
         },
         object: ({ chosenSteps, meta }) => {
           return Object.keys(chosenSteps).some((key) =>
-            meta.target.includes(key as StepNumbers<value>)
+            meta.target.includes(key as StepNumbers<value>),
           );
         },
       });

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -3,24 +3,20 @@ import {
   DEFAULT_CASING,
   DEFAULT_STORAGE_KEY,
   type Expand,
-  type HelperFn,
   type HelperFnChosenSteps,
   MultiStepFormSchema as MultiStepFormSchemaCore,
   MultiStepFormStorage,
   type StepNumbers,
 } from '@jfdevelops/multi-step-form-core';
-import {
-  MultiStepFormStepSchemaInternal,
-  type StepSchema,
-} from '@jfdevelops/multi-step-form-core/_internals';
+import type { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
 import {
   createMultiStepFormContext,
   type MultiStepFormContextResult,
 } from './create-context';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { type HelperFunctions, MultiStepFormStepSchema } from './step-schema';
-import { createComponent, type CreateComponentCallback } from './utils';
-import { type instantiateReactSteps } from './steps';
+import type { CreateComponent } from './utils';
+import { type instantiateReactSteps, StepSpecificComponent } from './steps';
 
 // Helper inference types for `AnyMultiStepFormSchema`
 export namespace MultiStepFormSchema {
@@ -40,16 +36,14 @@ export namespace MultiStepFormSchema {
   };
 
   type resolvedStepFunctionKey =
-    | 'createComponent'
-    | 'createHelperFn'
-    | 'isComplete'
-    | 'reset'
-    | 'update';
+    'createComponent' | 'createHelperFn' | 'isComplete' | 'reset' | 'update';
   type withoutResolvedStepFunctions<value extends instantiateReactSteps> = {
     [key in keyof value]: Expand<{
-      [property in keyof value[key] as property extends resolvedStepFunctionKey
-        ? never
-        : property]: value[key][property];
+      [
+        property in keyof value[key] as property extends resolvedStepFunctionKey
+          ? never
+          : property
+      ]: value[key][property];
     }>;
   };
 
@@ -66,13 +60,14 @@ export namespace MultiStepFormSchema {
     def extends StepSchema.Config,
     formConfig extends object,
     value extends instantiateReactSteps<def> = instantiateReactSteps<def>,
-  > = withFormValueCandidate<
-    def,
-    formConfig,
-    value
-  > extends instantiateReactSteps<withFormDef<def, formConfig>>
-    ? withFormValueCandidate<def, formConfig, value>
-    : instantiateReactSteps<withFormDef<def, formConfig>>;
+  > =
+    withFormValueCandidate<
+      def,
+      formConfig,
+      value
+    > extends instantiateReactSteps<withFormDef<def, formConfig>>
+      ? withFormValueCandidate<def, formConfig, value>
+      : instantiateReactSteps<withFormDef<def, formConfig>>;
 
   export type config<
     def extends StepSchema.Config,
@@ -98,8 +93,6 @@ export class MultiStepFormSchema<
 {
   // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
   stepSchema: MultiStepFormStepSchema<def, value>;
-  // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
-  readonly #internal: MultiStepFormStepSchemaInternal<def, value>;
   // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
   override readonly storage: MultiStepFormStorage<
     value,
@@ -133,17 +126,6 @@ export class MultiStepFormSchema<
     this.stepSchema = new MultiStepFormStepSchema(options);
     this.stepSchema.subscribe(() => {
       this.notify();
-    });
-    // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
-    this.#internal = new MultiStepFormStepSchemaInternal<def, value>({
-      originalValue: this.stepSchema.original,
-      defaultNameTransformationCasing: this.stepSchema.defaultNameTransformationCasing,
-      getValue: () => this.stepSchema.value,
-      setValue: (value) => {
-        this.stepSchema.value = { ...value };
-        this.storage.add(value);
-        this.notify();
-      },
     });
     this.storageConfig = {
       key: (storage?.key ??
@@ -241,18 +223,13 @@ export class MultiStepFormSchema<
   createComponent<
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
     props = undefined,
-  >(
-    options: HelperFn.BaseOptions<value, chosenSteps>,
-    fn: CreateComponentCallback<value, chosenSteps, props>,
-  ) {
-    return createComponent({
-      fn,
-      input: ({ stepData }) => ({
-        reset: this.#internal.createHelperFnInputReset(stepData),
-        update: this.#internal.createHelperFnInputUpdate(stepData),
-      }),
-      options,
-      value: this.stepSchema.value,
-    });
+  >(config: {
+    stepData: chosenSteps;
+    render: CreateComponent<
+      StepSpecificComponent.instanceInput<def, value, chosenSteps>,
+      props
+    >;
+  }) {
+    return this.stepSchema.createComponent(config);
   }
 }

--- a/packages/react/src/schema.ts
+++ b/packages/react/src/schema.ts
@@ -3,10 +3,8 @@ import {
   DEFAULT_CASING,
   DEFAULT_STORAGE_KEY,
   type Expand,
-  type HelperFnChosenSteps,
   MultiStepFormSchema as MultiStepFormSchemaCore,
   MultiStepFormStorage,
-  type StepNumbers,
 } from '@jfdevelops/multi-step-form-core';
 import type { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
 import {
@@ -14,9 +12,12 @@ import {
   type MultiStepFormContextResult,
 } from './create-context';
 import { MultiStepFormSchemaConfig } from './form-config';
-import { type HelperFunctions, MultiStepFormStepSchema } from './step-schema';
-import type { CreateComponent } from './utils';
-import { type instantiateReactSteps, StepSpecificComponent } from './steps';
+import {
+  type CreateComponentFn,
+  type HelperFunctions,
+  MultiStepFormStepSchema,
+} from './step-schema';
+import type { instantiateReactSteps } from './steps';
 
 // Helper inference types for `AnyMultiStepFormSchema`
 export namespace MultiStepFormSchema {
@@ -220,16 +221,7 @@ export class MultiStepFormSchema<
     return next;
   }
 
-  createComponent<
-    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-    props = undefined,
-  >(config: {
-    stepData: chosenSteps;
-    render: CreateComponent<
-      StepSpecificComponent.instanceInput<def, value, chosenSteps>,
-      props
-    >;
-  }) {
-    return this.stepSchema.createComponent(config);
+  get createComponent(): CreateComponentFn<def, value> {
+    return this.stepSchema.createComponent;
   }
 }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -32,37 +32,36 @@ import {
 } from './steps';
 import {
   createComponent,
-  type CreateComponentCallback,
+  type CreateComponent,
   type CreatedMultiStepFormComponent,
   getValidatedCustomInputHooks,
   resolvedCtxCreator,
 } from './utils';
-import {
-  Suspense,
-  createElement,
-  useEffect,
-  type ReactNode,
-} from 'react';
+import { Suspense, createElement, useEffect, type ReactNode } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 
 export type CreateComponentFn<
   def extends StepSchema.Config,
-  value extends instantiateReactSteps<def>
+  value extends instantiateReactSteps<def>,
 > = <targetStep extends StepNumbers<value>, props = undefined>(
-  options: HelperFn.BaseOptions<value, [targetStep]>,
-  fn: CreateComponentCallback<value, [targetStep], props>
+  config: HelperFn.BaseOptions<value, [targetStep]> & {
+    render: CreateComponent<
+      StepSpecificComponent.instanceInput<def, value, [targetStep]>,
+      props
+    >;
+  },
 ) => CreatedMultiStepFormComponent<props>;
 
 export interface HelperFunctions<
   def extends StepSchema.Config,
-  value extends instantiateReactSteps<def>
+  value extends instantiateReactSteps<def>,
 > {
   createComponent: CreateComponentFn<def, value>;
 }
 namespace CreateComponentImplConfig {
   export type stepSpecificConfig<
     def extends StepSchema.Config,
-    _value extends instantiateReactSteps<def>
+    _value extends instantiateReactSteps<def>,
   > = {
     isStepSpecific: true;
     defaultId: string;
@@ -75,14 +74,14 @@ namespace CreateComponentImplConfig {
 
   export type config<
     def extends StepSchema.Config,
-    value extends instantiateReactSteps<def>
+    value extends instantiateReactSteps<def>,
   > = nonStepSpecific | stepSpecificConfig<def, value>;
 }
 
 export namespace MultiStepFormStepSchema {
   export type config<
     def extends StepSchema.Config,
-    value extends instantiateReactSteps<def>
+    value extends instantiateReactSteps<def>,
   > = def & {
     /**
      * The form configuration.
@@ -97,9 +96,9 @@ export namespace MultiStepFormStepSchema {
 }
 
 export class MultiStepFormStepSchema<
-    const def extends StepSchema.Config,
-    value extends instantiateReactSteps<def> = instantiateReactSteps<def>
-  >
+  const def extends StepSchema.Config,
+  value extends instantiateReactSteps<def> = instantiateReactSteps<def>,
+>
   extends MultiStepFormStepSchemaBase<def>
   implements HelperFunctions<def, value>
 {
@@ -153,12 +152,12 @@ export class MultiStepFormStepSchema<
     // Safe to use tuple notation here since the step specific `createComponent` will always have
     // `stepData` as a tuple
     chosenStep extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>,
-    additionalCtx extends Record<string, unknown>
+    additionalCtx extends Record<string, unknown>,
   >(
     options: {
       stepData: chosenStep;
       logger: MultiStepFormLogger;
-    } & HelperFn.CtxDataSelector<value, chosenStep, additionalCtx>
+    } & HelperFn.CtxDataSelector<value, chosenStep, additionalCtx>,
   ) {
     const { logger, stepData, ctxData } = options;
     // Create ctx fresh each time to ensure it has the latest this.value
@@ -231,7 +230,10 @@ export class MultiStepFormStepSchema<
       return deepEqual(first, second);
     }
 
-    const useStep = <TError extends Error = Error, TSelected = StepResult<TError>>(
+    const useStep = <
+      TError extends Error = Error,
+      TSelected = StepResult<TError>,
+    >(
       options?: StepSpecificComponent.useStepOptions<
         def,
         value,
@@ -286,16 +288,16 @@ export class MultiStepFormStepSchema<
     // Safe to use tuple notation here since the step specific `createComponent` will always have
     // `stepData` as a tuple
     chosenStep extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>,
-    additionalCtx extends Record<string, unknown> = {}
+    additionalCtx extends Record<string, unknown> = {},
   >(
     stepData: chosenStep,
     config: CreateComponentImplConfig.stepSpecificConfig<def, value>,
     extraConfig?: {
       logger?: MultiStepFormLogger;
       input?: (
-        ctx: Expand<HelperFn.buildCtx<value, chosenStep>>
+        ctx: Expand<HelperFn.buildCtx<value, chosenStep>>,
       ) => Record<string, unknown>;
-    } & HelperFn.CtxDataSelector<value, chosenStep, additionalCtx>
+    } & HelperFn.CtxDataSelector<value, chosenStep, additionalCtx>,
   ) {
     const [step] = stepData;
     return <props>(fn: Function) =>
@@ -313,25 +315,19 @@ export class MultiStepFormStepSchema<
         const hookResults = getValidatedCustomInputHooks(extraInput);
         const { defaultId, form } = config;
 
-        InvalidStepError.invariant(
-          this.steps.isValidStep(step),
-          {
-            reason: `The target step ${step} is invalid`,
-            targetStep: step,
-            validSteps: [...this.steps.value],
-          },
-        );
+        InvalidStepError.invariant(this.steps.isValidStep(step), {
+          reason: `The target step ${step} is invalid`,
+          targetStep: step,
+          validSteps: [...this.steps.value],
+        });
 
         const stepNumber = Number.parseInt(step.replace('step', ''));
 
-        InvalidInternalStateError.invariant(
-          !Number.isNaN(stepNumber),
-          {
-            reason: `Unable to extract a number from ${step}`,
-            operation: 'createComponent',
-            value: step,
-          },
-        );
+        InvalidInternalStateError.invariant(!Number.isNaN(stepNumber), {
+          reason: `Unable to extract a number from ${step}`,
+          operation: 'createComponent',
+          value: step,
+        });
         const current = this.value[step];
 
         InvalidInternalStateError.invariant(
@@ -345,14 +341,11 @@ export class MultiStepFormStepSchema<
         // These checks are mostly for type safety. `current` should _always_ be in the proper format.
         // On the off chance that it's not, we have the checks here to help, but these checks are basically
         // just for type safety.
-        InvalidInternalStateError.invariant(
-          'fields' in current,
-          {
-            reason: 'Unable to find the "fields" for the current step',
-            operation: 'createComponent',
-            value: current,
-          },
-        );
+        InvalidInternalStateError.invariant('fields' in current, {
+          reason: 'Unable to find the "fields" for the current step',
+          operation: 'createComponent',
+          value: current,
+        });
         InvalidInternalStateError.invariant(
           typeof current.fields === 'object',
           {
@@ -369,51 +362,40 @@ export class MultiStepFormStepSchema<
             // Access current step data directly to avoid stale closure
             const currentStep = this.value[step] as typeof current;
             const currentFields = Object.keys(
-              currentStep.fields as Record<string, unknown>
+              currentStep.fields as Record<string, unknown>,
             );
-            InvalidFieldError.invariant(
-              typeof name === 'string',
-              {
-                reason: `The "name" prop must be a string and a valid field for ${step}`,
-                targetStep: step,
-                field: name,
-                validFields: currentFields,
-              },
-            );
+            InvalidFieldError.invariant(typeof name === 'string', {
+              reason: `The "name" prop must be a string and a valid field for ${step}`,
+              targetStep: step,
+              field: name,
+              validFields: currentFields,
+            });
             // TODO add support for deep keys (`name`)
 
             const allAvailableFields = path
               .createDeep(currentStep.fields)
               .map((value) => (value as string).replace('.defaultValue.', '.'));
 
-            InvalidFieldError.invariant(
-              allAvailableFields.includes(name),
-              {
-                reason: `The field "${name}" doesn't exist for ${step}`,
-                targetStep: step,
-                field: name,
-                validFields: allAvailableFields,
-              },
-            );
-            InvalidInternalStateError.invariant(
-              'update' in currentStep,
-              {
-                reason: `No "update" function was found for ${step}`,
-                operation: 'Field',
-                value: currentStep,
-              },
-            );
+            InvalidFieldError.invariant(allAvailableFields.includes(name), {
+              reason: `The field "${name}" doesn't exist for ${step}`,
+              targetStep: step,
+              field: name,
+              validFields: allAvailableFields,
+            });
+            InvalidInternalStateError.invariant('update' in currentStep, {
+              reason: `No "update" function was found for ${step}`,
+              operation: 'Field',
+              value: currentStep,
+            });
 
             const defaultValue = this.getValue(step as never, name);
             const builtValuePath = buildValuePath(name);
             const fieldName = String(name);
             const [parentFieldName] = fieldName.split('.');
             const fieldsRecord = currentStep.fields as Record<string, unknown>;
-            const {
-              label,
-              nameTransformCasing,
-              type,
-            } = fieldsRecord[parentFieldName] as {
+            const { label, nameTransformCasing, type } = fieldsRecord[
+              parentFieldName
+            ] as {
               label?: unknown;
               nameTransformCasing?: unknown;
               type?: unknown;
@@ -429,10 +411,10 @@ export class MultiStepFormStepSchema<
               name,
               onInputChange: <
                 strict extends boolean = true,
-                partial extends boolean = false
+                partial extends boolean = false,
               >(
                 value: unknown,
-                options?: field.onInputChangeOptions<strict, partial>
+                options?: field.onInputChangeOptions<strict, partial>,
               ) => {
                 // Handle Updater pattern: if value is a function, call it with the current field value
                 let resolvedValue;
@@ -482,7 +464,7 @@ export class MultiStepFormStepSchema<
         // Pass a function that creates fresh ctx on each call to avoid stale closures
         const useSelector = createUseSelector(
           () => this.createResolvedCtx({ stepData, ctxData, logger }) as never,
-          this.subscribe
+          this.subscribe,
         );
 
         // Create Selector component that uses useSelector internally
@@ -490,7 +472,7 @@ export class MultiStepFormStepSchema<
         // causing the parent component to re-render
         const Selector = selector.create(
           () => this.createResolvedCtx({ stepData, ctxData, logger }) as never,
-          this.subscribe
+          this.subscribe,
         );
         const useStep = this.createUseStep(step);
         const SuspendStep = this.createStepSuspend(step);
@@ -520,8 +502,8 @@ export class MultiStepFormStepSchema<
             MultiStepFormSchemaConfig.DEFAULT_FORM_ALIAS;
           const enabledFor =
             (instantiated.enabledForSteps as
-              | MultiStepFormSchemaConfig.formEnabledFor<value>
-              | undefined) ?? 'all';
+              MultiStepFormSchemaConfig.formEnabledFor<value> | undefined) ??
+            'all';
 
           InvalidFormConfigError.invariant(typeof alias === 'string', {
             reason: 'The alias must be a string',
@@ -533,7 +515,7 @@ export class MultiStepFormStepSchema<
           if (
             MultiStepFormSchemaConfig.isFormAvailable(
               stepData as never,
-              enabledFor as never
+              enabledFor as never,
             )
           ) {
             fnInput = {
@@ -551,104 +533,123 @@ export class MultiStepFormStepSchema<
             [MultiStepFormSchemaConfig.DEFAULT_FORM_ALIAS]:
               MultiStepFormSchemaConfig.createDefaultForm(defaultId),
           },
-          props
+          props,
         );
       }) as CreatedMultiStepFormComponent<props>;
   }
 
   private createStepSpecificComponentFactory<
-    targetStep extends StepNumbers<value>
+    targetStep extends StepNumbers<value>,
   >(
     targetStep: targetStep,
-    config: CreateComponentImplConfig.stepSpecificConfig<def, value>
+    config: CreateComponentImplConfig.stepSpecificConfig<def, value>,
   ) {
-    const impl = <additionalCtx extends Record<string, unknown> = {}, props = undefined>(
-      optionsOrFn:
-        | StepSpecificComponent.options<value, targetStep, additionalCtx>
-        | StepSpecificComponent.callback<def, value, targetStep, props, additionalCtx>,
-      fn?: StepSpecificComponent.callback<def, value, targetStep, props, additionalCtx>
+    const impl = <
+      additionalCtx extends Record<string, unknown> = {},
+      props = undefined,
+    >(
+      componentConfig: StepSpecificComponent.config<
+        def,
+        value,
+        targetStep,
+        props,
+        additionalCtx
+      >,
     ) => {
-      const createStepSpecificComponent = () => {
-        InvalidComponentError.invariant(
-          typeof optionsOrFn === 'function',
-          {
-            reason: 'The first argument must be a function',
-            component: 'createStepSpecificComponent',
-            argument: 'optionsOrFn',
-            value: optionsOrFn,
-          },
-        );
+      InvalidComponentError.invariant(
+        typeof componentConfig === 'object' && componentConfig !== null,
+        {
+          reason: 'The argument must be a component configuration object',
+          component: 'createStepSpecificComponent',
+          argument: 'config',
+          value: componentConfig,
+        },
+      );
 
-        return this.createStepSpecificComponentImpl(
-          [targetStep],
-          config
-        )(optionsOrFn);
-      };
+      const { ctxData, debug, render } = componentConfig;
 
-      if (typeof optionsOrFn === 'object') {
-        const { ctxData, debug } = optionsOrFn;
-        const logger = new MultiStepFormLogger({
-          debug,
-          prefix(prefix) {
-            return `${prefix}-${targetStep}-createComponent`;
-          },
-        });
+      InvalidComponentError.invariant(typeof render === 'function', {
+        reason: 'The "render" property must be a function',
+        component: 'createStepSpecificComponent',
+        argument: 'config.render',
+        value: render,
+      });
 
-        logger.info('First argument is an object');
+      const logger = new MultiStepFormLogger({
+        debug,
+        prefix(prefix) {
+          return `${prefix}-${targetStep}-createComponent`;
+        },
+      });
 
-        InvalidComponentError.invariant(
-          typeof fn === 'function',
-          {
-            reason: 'The second argument must be a function',
-            component: 'createStepSpecificComponent',
-            argument: 'fn',
-            value: fn,
-          },
-        );
-
-        if (ctxData) {
-          return this.createStepSpecificComponentImpl([targetStep], config, {
-            logger,
-            ctxData,
-          })(fn);
-        }
-
-        return createStepSpecificComponent();
-      }
-
-      return createStepSpecificComponent();
+      return this.createStepSpecificComponentImpl([targetStep], config, {
+        logger,
+        ctxData,
+      })(render);
     };
 
     return impl as StepSpecificCreateComponentFn<def, value, targetStep>;
   }
 
   /**
-   * A helper function to create a component for a specific step.
-   * @param options The options for creating the step specific component.
-   * @param fn A callback that is used for accessing the target step's data and defining
-   * any props that the component should have. This function must return a valid `JSX` element.
-   * @returns The created component for the step.
+   * Creates a component from selected step data and an object-based render configuration.
    */
   createComponent<
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-    props = undefined
+    props = undefined,
   >(
-    options: HelperFn.BaseOptions<value, chosenSteps>,
-    fn: CreateComponentCallback<value, chosenSteps, props>
+    componentConfig: HelperFn.BaseOptions<value, chosenSteps> & {
+      render: CreateComponent<
+        StepSpecificComponent.instanceInput<def, value, chosenSteps>,
+        props
+      >;
+    },
   ) {
-    return createComponent({
-      fn,
+    InvalidComponentError.invariant(
+      typeof componentConfig === 'object' && componentConfig !== null,
+      {
+        reason: 'The argument must be a component configuration object',
+        component: 'createComponent',
+        argument: 'config',
+        value: componentConfig,
+      },
+    );
+
+    const { render, ...options } = componentConfig;
+
+    InvalidComponentError.invariant(typeof render === 'function', {
+      reason: 'The "render" property must be a function',
+      component: 'createComponent',
+      argument: 'config.render',
+      value: render,
+    });
+
+    // A single-step instance component delegates to the step-specific implementation so its
+    // runtime input and public type stay identical as new step utilities are added.
+    if (Array.isArray(options.stepData) && options.stepData.length === 1) {
+      const [targetStep] = options.stepData as [StepNumbers<value>];
+      const step = this.value[targetStep] as {
+        createComponent: (config: {
+          render: unknown;
+        }) => CreatedMultiStepFormComponent<props>;
+      };
+
+      return step.createComponent({ render } as never);
+    }
+
+    return createComponent<value, chosenSteps, props>({
+      render: render as never,
       input: ({ stepData }) => ({
         reset: this.#internal.createHelperFnInputReset(stepData),
         update: this.#internal.createHelperFnInputUpdate(stepData),
       }),
-      options,
+      options: options as HelperFn.BaseOptions<value, chosenSteps>,
       value: this.value,
     });
   }
 
   createDefaultValues<targetStep extends StepNumbers<value>>(
-    targetStep: targetStep
+    targetStep: targetStep,
   ) {
     return getDefaultValues(this.value, targetStep);
   }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -4,6 +4,7 @@ import {
   instantiateSteps as instantiateStepsCore,
   type Expand,
   getDefaultValues,
+  type getDeepFields,
   type HelperFn,
   type HelperFnChosenSteps,
   InvalidComponentError,
@@ -40,17 +41,34 @@ import {
 import { Suspense, createElement, useEffect, type ReactNode } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 
-export type CreateComponentFn<
+export interface CreateComponentFn<
   def extends StepSchema.Config,
   value extends instantiateReactSteps<def>,
-> = <targetStep extends StepNumbers<value>, props = undefined>(
-  config: HelperFn.BaseOptions<value, [targetStep]> & {
-    render: CreateComponent<
-      StepSpecificComponent.instanceInput<def, value, [targetStep]>,
+> {
+  <targetStep extends StepNumbers<value>, props = undefined>(
+    config: HelperFn.BaseOptions<value, [targetStep]> & {
+      render: CreateComponent<
+        StepSpecificComponent.instanceInput<def, value, [targetStep]>,
+        props
+      >;
+    },
+  ): CreatedMultiStepFormComponent<props>;
+
+  /** Creates a reusable component bound to one field in one step. */
+  forField<
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    props = undefined,
+  >(
+    config: StepSpecificComponent.fieldConfig<
+      def,
+      value,
+      targetStep,
+      targetField,
       props
-    >;
-  },
-) => CreatedMultiStepFormComponent<props>;
+    > & { step: targetStep },
+  ): CreatedMultiStepFormComponent<props>;
+}
 
 export interface HelperFunctions<
   def extends StepSchema.Config,
@@ -106,6 +124,7 @@ export class MultiStepFormStepSchema<
   value: value;
   // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
   readonly #internal: MultiStepFormStepSchemaInternal<def, value>;
+  readonly createComponent: CreateComponentFn<def, value>;
 
   constructor(config: MultiStepFormStepSchema.config<def, value>) {
     const { form, ...rest } = config;
@@ -146,6 +165,51 @@ export class MultiStepFormStepSchema<
         }),
       };
     });
+
+    // A function object preserves the callable factory while grouping the field-specific
+    // variant under the API it specializes.
+    this.createComponent = Object.assign(this.createComponentImpl.bind(this), {
+      forField: <
+        targetStep extends StepNumbers<value>,
+        targetField extends getDeepFields<value, targetStep>,
+        props = undefined,
+      >(
+        componentConfig: StepSpecificComponent.fieldConfig<
+          def,
+          value,
+          targetStep,
+          targetField,
+          props
+        > & { step: targetStep },
+      ) => {
+        InvalidComponentError.invariant(
+          typeof componentConfig === 'object' && componentConfig !== null,
+          {
+            reason:
+              'The argument must be a field component configuration object',
+            component: 'createFieldComponent',
+            argument: 'config',
+            value: componentConfig,
+          },
+        );
+
+        const { step, ...fieldConfig } = componentConfig;
+        InvalidStepError.invariant(this.steps.isValidStep(step), {
+          reason: `The target step ${step} is invalid`,
+          targetStep: step,
+          validSteps: [...this.steps.value],
+        });
+        const target = this.value[step] as {
+          createComponent: StepSpecificCreateComponentFn<
+            def,
+            value,
+            targetStep
+          >;
+        };
+
+        return target.createComponent.forField(fieldConfig as never);
+      },
+    }) as CreateComponentFn<def, value>;
   }
 
   private createResolvedCtx<
@@ -588,13 +652,66 @@ export class MultiStepFormStepSchema<
       })(render);
     };
 
-    return impl as StepSpecificCreateComponentFn<def, value, targetStep>;
+    const forField = <
+      targetField extends getDeepFields<value, targetStep>,
+      props = undefined,
+    >(
+      fieldConfig: StepSpecificComponent.fieldConfig<
+        def,
+        value,
+        targetStep,
+        targetField,
+        props
+      >,
+    ) => {
+      InvalidComponentError.invariant(
+        typeof fieldConfig === 'object' && fieldConfig !== null,
+        {
+          reason: 'The argument must be a field component configuration object',
+          component: 'createFieldComponent',
+          argument: 'config',
+          value: fieldConfig,
+        },
+      );
+
+      const { field: targetField, render } = fieldConfig;
+
+      InvalidComponentError.invariant(typeof render === 'function', {
+        reason: 'The "render" property must be a function',
+        component: 'createFieldComponent',
+        argument: 'config.render',
+        value: render,
+      });
+
+      // Reuse the existing Field component so specialized components inherit its subscriptions,
+      // validation, deep-field support, and update/reset behavior.
+      return impl({
+        render: (
+          { Field }: StepSpecificComponent.input<def, value, targetStep, {}>,
+          props: props,
+        ) =>
+          createElement(
+            Field as never,
+            {
+              name: targetField,
+              children: (fieldProps: unknown) =>
+                render(fieldProps as never, props),
+            } as never,
+          ),
+      } as never);
+    };
+
+    return Object.assign(impl, { forField }) as StepSpecificCreateComponentFn<
+      def,
+      value,
+      targetStep
+    >;
   }
 
   /**
    * Creates a component from selected step data and an object-based render configuration.
    */
-  createComponent<
+  private createComponentImpl<
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
     props = undefined,
   >(

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -58,16 +58,22 @@ export interface CreateComponentFn<
   forField<
     targetStep extends StepNumbers<value>,
     targetField extends getDeepFields<value, targetStep>,
-    props = undefined,
+    customProps extends object = {},
   >(
     config: StepSpecificComponent.fieldConfig<
       def,
       value,
       targetStep,
       targetField,
-      props
+      customProps
     > & { step: targetStep },
-  ): CreatedMultiStepFormComponent<props>;
+  ): StepSpecificComponent.fieldComponent<
+    def,
+    value,
+    targetStep,
+    targetField,
+    customProps
+  >;
 }
 
 export interface HelperFunctions<
@@ -172,14 +178,14 @@ export class MultiStepFormStepSchema<
       forField: <
         targetStep extends StepNumbers<value>,
         targetField extends getDeepFields<value, targetStep>,
-        props = undefined,
+        customProps extends object = {},
       >(
         componentConfig: StepSpecificComponent.fieldConfig<
           def,
           value,
           targetStep,
           targetField,
-          props
+          customProps
         > & { step: targetStep },
       ) => {
         InvalidComponentError.invariant(
@@ -654,14 +660,14 @@ export class MultiStepFormStepSchema<
 
     const forField = <
       targetField extends getDeepFields<value, targetStep>,
-      props = undefined,
+      customProps extends object = {},
     >(
       fieldConfig: StepSpecificComponent.fieldConfig<
         def,
         value,
         targetStep,
         targetField,
-        props
+        customProps
       >,
     ) => {
       InvalidComponentError.invariant(
@@ -688,14 +694,24 @@ export class MultiStepFormStepSchema<
       return impl({
         render: (
           { Field }: StepSpecificComponent.input<def, value, targetStep, {}>,
-          props: props,
+          componentProps: StepSpecificComponent.fieldComponentProps<
+            def,
+            value,
+            targetStep,
+            targetField,
+            customProps
+          >,
         ) =>
           createElement(
             Field as never,
             {
+              ...componentProps,
               name: targetField,
               children: (fieldProps: unknown) =>
-                render(fieldProps as never, props),
+                render(
+                  fieldProps as never,
+                  componentProps as unknown as customProps,
+                ),
             } as never,
           ),
       } as never);

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -17,13 +17,17 @@ import { field } from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { UseSelector } from './hooks/use-selector';
 import { selector } from './selector';
-import { CreateComponent, CreatedMultiStepFormComponent } from './utils';
+import {
+  CreateComponent,
+  type CreateComponentConfig,
+  CreatedMultiStepFormComponent,
+} from './utils';
 
 export namespace StepSpecificComponent {
   type defaultFormComponent = {
-    [key in MultiStepFormSchemaConfig.defaultFormAlias]: CreatedMultiStepFormComponent<
-      Omit<ComponentPropsWithRef<'form'>, 'id'>
-    >;
+    [
+      key in MultiStepFormSchemaConfig.defaultFormAlias
+    ]: CreatedMultiStepFormComponent<Omit<ComponentPropsWithRef<'form'>, 'id'>>;
   };
   type instantiateFormComponentForAllSteps<
     def extends StepSchema.Config,
@@ -72,12 +76,8 @@ export namespace StepSpecificComponent {
     tuple: instantiateFormComponentForTuple<def, steps, chosenSteps>;
     object: instantiateFormComponentForObject<def, steps, chosenSteps>;
   };
-  // The logic for getting the formCtx only works for step specific `createComponent`
-  // (i.e: step1.createComponent(...)) as of now. Reason is because I can't think of a good API for integrating the form
-  // ctx into the main `createComponent` since multiple steps can be chosen. In that case
-  // how would the logic work for when the form component should be defined in the callback?
-  // Ideas:
-  //  - Make the main `createComponent` return a function that accepts the current step
+  // A form component can only be selected unambiguously when one concrete step is targeted.
+  // Instance-level `createComponent` delegates that case to the same step-specific factory.
   export type formComponent<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps<def>,
@@ -132,7 +132,10 @@ export namespace StepSpecificComponent {
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
-  > = <error extends Error = Error, selected = useStepResult<value, targetStep, error>>(
+  > = <
+    error extends Error = Error,
+    selected = useStepResult<value, targetStep, error>,
+  >(
     options?: useStepOptions<def, value, targetStep, error, selected>,
   ) => selected;
 
@@ -240,6 +243,33 @@ export namespace StepSpecificComponent {
      */
     debug?: boolean;
   };
+
+  export type config<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    props,
+    additionalCtx extends Record<string, unknown> = {},
+  > = options<value, targetStep, additionalCtx> &
+    CreateComponentConfig<
+      Expand<
+        input<def, value, targetStep, additionalCtx> &
+          formComponent<def, value, [targetStep]> &
+          additionalCtx
+      >,
+      props
+    >;
+
+  export type instanceInput<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  > = chosenSteps extends [infer targetStep extends StepNumbers<value>]
+    ? Expand<
+        input<def, value, targetStep, {}> &
+          formComponent<def, value, [targetStep]>
+      >
+    : HelperFnInput.BaseInput<value, chosenSteps, never, {}>;
 }
 
 type IsLegacyFormAvailable<
@@ -277,20 +307,11 @@ export interface StepSpecificCreateComponentFn<
 > {
   /**
    * A utility function to easily create a component for the current step.
-   * @param fn The callback function where the component is defined.
-   */
-  <props = undefined>(
-    fn: StepSpecificComponent.callback<def, value, targetStep, props>,
-  ): CreatedMultiStepFormComponent<props>;
-  /**
-   * A utility function to easily create a component for the current step.
-   * @param options Specific config options for creating a component for the current step.
-   * @param fn The callback function where the component is defined.
+   * @param config Specific options and the render callback for the component.
    * @returns The created component.
    */
   <additionalCtx extends Record<string, unknown> = {}, props = undefined>(
-    options: StepSpecificComponent.options<value, targetStep, additionalCtx>,
-    fn: StepSpecificComponent.callback<
+    config: StepSpecificComponent.config<
       def,
       value,
       targetStep,

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -266,19 +266,53 @@ export namespace StepSpecificComponent {
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
     targetField extends getDeepFields<value, targetStep>,
-  > = field.childrenProps<value, targetField, targetStep>;
+  > = field.childrenProps<value, targetField, targetStep> & {
+    /** Present when the returned component receives a `selectorFn`. */
+    selected?: { value: unknown };
+  };
+
+  export type fieldComponentProps<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+  > = Expand<
+    // `forField` owns these two props so callers cannot replace its field binding or renderer.
+    Omit<
+      field.boundProps<value, targetStep, targetField, unknown>,
+      'name' | 'children'
+    > &
+      Omit<customProps, 'name' | 'children'>
+  >;
+
+  export type fieldComponent<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+  > = (
+    props: fieldComponentProps<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps
+    >,
+  ) => ReactNode;
 
   export type fieldConfig<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
     targetField extends getDeepFields<value, targetStep>,
-    props,
+    customProps extends object,
   > = {
     field: targetField;
     render: CreateComponent<
       fieldInput<def, value, targetStep, targetField>,
-      props
+      customProps
     >;
   };
 
@@ -345,16 +379,22 @@ export interface StepSpecificCreateComponentFn<
   /** Creates a reusable component bound to one field in this step. */
   forField<
     targetField extends getDeepFields<value, targetStep>,
-    props = undefined,
+    customProps extends object = {},
   >(
     config: StepSpecificComponent.fieldConfig<
       def,
       value,
       targetStep,
       targetField,
-      props
+      customProps
     >,
-  ): CreatedMultiStepFormComponent<props>;
+  ): StepSpecificComponent.fieldComponent<
+    def,
+    value,
+    targetStep,
+    targetField,
+    customProps
+  >;
 }
 
 /**

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -2,6 +2,7 @@ import type {
   _instantiateSteps,
   BaseStepFunctions,
   Expand,
+  getDeepFields,
   getDefaultValues,
   HelperFn,
   HelperFnChosenSteps,
@@ -102,7 +103,7 @@ export namespace StepSpecificComponent {
      */
     reset: ResetFn.stepSpecific<value, targetStep>;
   };
-  type buildCurrentStep<
+  export type buildCurrentStep<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
@@ -260,6 +261,27 @@ export namespace StepSpecificComponent {
       props
     >;
 
+  export type fieldInput<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+  > = field.childrenProps<value, targetField, targetStep>;
+
+  export type fieldConfig<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    props,
+  > = {
+    field: targetField;
+    render: CreateComponent<
+      fieldInput<def, value, targetStep, targetField>,
+      props
+    >;
+  };
+
   export type instanceInput<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
@@ -317,6 +339,20 @@ export interface StepSpecificCreateComponentFn<
       targetStep,
       props,
       additionalCtx
+    >,
+  ): CreatedMultiStepFormComponent<props>;
+
+  /** Creates a reusable component bound to one field in this step. */
+  forField<
+    targetField extends getDeepFields<value, targetStep>,
+    props = undefined,
+  >(
+    config: StepSpecificComponent.fieldConfig<
+      def,
+      value,
+      targetStep,
+      targetField,
+      props
     >,
   ): CreatedMultiStepFormComponent<props>;
 }

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -12,36 +12,30 @@ import type { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
 import type { ReactNode } from 'react';
 export function resolvedCtxCreator<
   def extends StepSchema.Config,
-  value extends instantiateSteps<def>
->(
-  logger: MultiStepFormLogger,
-  values: object
-) {
+  value extends instantiateSteps<def>,
+>(logger: MultiStepFormLogger, values: object) {
   return function <
     chosenStep extends HelperFnChosenSteps.tupleNotation<StepNumbers<value>>,
-    additionalCtx extends Record<string, unknown> = {}
+    additionalCtx extends Record<string, unknown> = {},
   >(
     options: Required<
       HelperFn.CtxDataSelector<value, chosenStep, additionalCtx>
     > &
-      HelperFn.BaseInput<value, chosenStep>
+      HelperFn.BaseInput<value, chosenStep>,
   ) {
     const { ctx, ctxData } = options;
 
     logger.info('Option "ctxData" is defined');
-    InvalidContextError.invariant(
-      typeof ctxData === 'function',
-      {
-        reason: 'Option "ctxData" must be a function',
-        value: ctxData,
-        expected: 'function',
-      },
-    );
+    InvalidContextError.invariant(typeof ctxData === 'function', {
+      reason: 'Option "ctxData" must be a function',
+      value: ctxData,
+      expected: 'function',
+    });
 
     const additionalCtx = ctxData({ ctx: values } as never);
 
     logger.info(
-      `Addition context is: ${JSON.stringify(additionalCtx, null, 2)}`
+      `Addition context is: ${JSON.stringify(additionalCtx, null, 2)}`,
     );
 
     const resolvedCtx = {
@@ -86,7 +80,7 @@ export function getValidatedCustomInputHooks(input: Record<string, unknown>) {
             `2. The hook has invalid dependencies or configuration\n` +
             `3. There's an error in your hook implementation\n\n` +
             `Original error: ${errorMessage}`,
-          { cause: error }
+          { cause: error },
         );
       }
     } else {
@@ -104,10 +98,13 @@ export type CreateComponent<TInput, TProps> = CreateFunction<
   [input: TInput, props: TProps],
   ReactNode
 >;
+export type CreateComponentConfig<TInput, TProps> = {
+  render: CreateComponent<TInput, TProps>;
+};
 export type CreateComponentCallback<
   value extends instantiateSteps,
   chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-  TProps
+  TProps,
 > = CreateComponent<
   HelperFnInput.BaseInput<value, chosenSteps, never, {}>,
   TProps
@@ -118,33 +115,33 @@ export type CreatedMultiStepFormComponent<TProps> = TProps extends undefined
 export type CreateComponentImplOptions<
   value extends instantiateSteps,
   chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-  props
+  props,
 > = {
   value: value;
   options: HelperFn.BaseOptions<value, chosenSteps>;
-  fn: CreateComponentCallback<value, chosenSteps, props>;
+  render: CreateComponentCallback<value, chosenSteps, props>;
   input: (
     options: {
       ctx: HelperFn.buildCtx<value, chosenSteps>;
-    } & HelperFn.BaseOptions<value, chosenSteps>
+    } & HelperFn.BaseOptions<value, chosenSteps>,
   ) => Omit<HelperFnInput.BaseInput<value, chosenSteps, never, {}>, 'ctx'>;
 };
 export function createComponent<
   value extends instantiateSteps,
   chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-  props
+  props,
 >({
   value,
   options,
-  fn,
+  render,
   input,
 }: CreateComponentImplOptions<value, chosenSteps, props>) {
   const { stepData } = options;
   const ctx = createCtx(value, stepData) as never;
 
   return ((props?: props) =>
-    fn(
+    render(
       { ctx, ...input({ ctx, stepData }) },
-      props as any
+      props as any,
     )) as CreatedMultiStepFormComponent<props>;
 }

--- a/packages/react/test/define.test.ts
+++ b/packages/react/test/define.test.ts
@@ -50,23 +50,7 @@ describe('react defineMultiStepForm: definition schema surface', () => {
     expect(definition.stepSchema.value.step1.title).toBe('Step 1');
     expect(typeof definition.withForm).toBe('function');
     expect(typeof definition.createComponent).toBe('function');
-    expect(typeof definition.createComponent.forField).toBe('function');
-    expect(
-      typeof definition.stepSchema.value.step1.createComponent.forField,
-    ).toBe('function');
 
-    const FirstName = definition.createComponent.forField({
-      step: 'step1',
-      field: 'firstName',
-      render(field) {
-        expectTypeOf(field.name).toEqualTypeOf<'firstName'>();
-        expectTypeOf(field.defaultValue).toEqualTypeOf<string>();
-
-        return null;
-      },
-    });
-
-    expectTypeOf(FirstName).toBeFunction();
     expect('stepNumbers' in definition).toBe(false);
   });
 
@@ -172,12 +156,6 @@ describe('react defineMultiStepForm: instances', () => {
       'Taylor',
     );
     expect(admin.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
-  });
-
-  it('exposes the reusable field factory from configure()', () => {
-    const createForm = createBookingDefinition().configure();
-
-    expect(typeof createForm.createComponent.forField).toBe('function');
   });
 
   it('rejects instances that were not declared', () => {

--- a/packages/react/test/define.test.ts
+++ b/packages/react/test/define.test.ts
@@ -50,6 +50,23 @@ describe('react defineMultiStepForm: definition schema surface', () => {
     expect(definition.stepSchema.value.step1.title).toBe('Step 1');
     expect(typeof definition.withForm).toBe('function');
     expect(typeof definition.createComponent).toBe('function');
+    expect(typeof definition.createComponent.forField).toBe('function');
+    expect(
+      typeof definition.stepSchema.value.step1.createComponent.forField,
+    ).toBe('function');
+
+    const FirstName = definition.createComponent.forField({
+      step: 'step1',
+      field: 'firstName',
+      render(field) {
+        expectTypeOf(field.name).toEqualTypeOf<'firstName'>();
+        expectTypeOf(field.defaultValue).toEqualTypeOf<string>();
+
+        return null;
+      },
+    });
+
+    expectTypeOf(FirstName).toBeFunction();
     expect('stepNumbers' in definition).toBe(false);
   });
 
@@ -155,6 +172,12 @@ describe('react defineMultiStepForm: instances', () => {
       'Taylor',
     );
     expect(admin.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
+  });
+
+  it('exposes the reusable field factory from configure()', () => {
+    const createForm = createBookingDefinition().configure();
+
+    expect(typeof createForm.createComponent.forField).toBe('function');
   });
 
   it('rejects instances that were not declared', () => {

--- a/packages/react/test/define.test.ts
+++ b/packages/react/test/define.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-import { InvalidInstanceError, NoActiveInstanceError } from '@jfdevelops/multi-step-form-core';
+import {
+  InvalidInstanceError,
+  NoActiveInstanceError,
+} from '@jfdevelops/multi-step-form-core';
 import { defineMultiStepForm, type MultiStepFormSchema } from '../src';
 
 function createMockStorage(): Storage {
@@ -37,6 +40,41 @@ function createBookingDefinition() {
   });
 }
 
+describe('react defineMultiStepForm: definition schema surface', () => {
+  it('exposes the React schema and a type-only exact step union', () => {
+    const definition = createBookingDefinition();
+
+    type Step = typeof definition.stepNumbers;
+
+    expectTypeOf<Step>().toEqualTypeOf<'step1'>();
+    expect(definition.stepSchema.value.step1.title).toBe('Step 1');
+    expect(typeof definition.withForm).toBe('function');
+    expect(typeof definition.createComponent).toBe('function');
+    expect('stepNumbers' in definition).toBe(false);
+  });
+
+  it('keeps definition and configured instance state independent', () => {
+    const definition = createBookingDefinition();
+    const client = definition.configure()({ instance: 'client' });
+
+    definition.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Definition',
+    });
+    client.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Client',
+    });
+
+    expect(
+      definition.stepSchema.value.step1.fields.firstName.defaultValue,
+    ).toBe('Definition');
+    expect(client.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+      'Client',
+    );
+  });
+});
+
 describe('react defineMultiStepForm: nameTransformCasing', () => {
   it('is not accepted at define time and threads through .configure() instead', () => {
     defineMultiStepForm({
@@ -55,7 +93,9 @@ describe('react defineMultiStepForm: nameTransformCasing', () => {
       nameTransformCasing: 'camel',
     });
 
-    expect(createForm().stepSchema.defaultNameTransformationCasing).toBe('camel');
+    expect(createForm().stepSchema.defaultNameTransformationCasing).toBe(
+      'camel',
+    );
   });
 });
 
@@ -82,7 +122,8 @@ describe('react defineMultiStepForm: public types', () => {
           },
         },
       },
-    }).configure()()
+    })
+      .configure()()
       .withForm({ render: () => null })
       .withContext();
 
@@ -110,7 +151,9 @@ describe('react defineMultiStepForm: instances', () => {
       updater: 'Taylor',
     });
 
-    expect(client.stepSchema.value.step1.fields.firstName.defaultValue).toBe('Taylor');
+    expect(client.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+      'Taylor',
+    );
     expect(admin.stepSchema.value.step1.fields.firstName.defaultValue).toBe('');
   });
 
@@ -118,7 +161,9 @@ describe('react defineMultiStepForm: instances', () => {
     const createForm = createBookingDefinition().configure();
 
     // @ts-expect-error "sales" isn't a declared instance
-    expect(() => createForm({ instance: 'sales' })).toThrow(InvalidInstanceError);
+    expect(() => createForm({ instance: 'sales' })).toThrow(
+      InvalidInstanceError,
+    );
   });
 
   it('returns instances that still support withForm/withContext', () => {
@@ -177,7 +222,9 @@ describe('react defineMultiStepForm: storage', () => {
     });
 
     createForm({ instance: 'client' });
-    expect(() => createForm({ instance: 'admin' })).toThrow(InvalidInstanceError);
+    expect(() => createForm({ instance: 'admin' })).toThrow(
+      InvalidInstanceError,
+    );
   });
 });
 
@@ -189,7 +236,9 @@ describe('react defineMultiStepForm: withOverrides', () => {
       step1: async () => ({ firstName: 'ClientDefault' }),
     });
 
-    await Reflect.apply(client.stepSchema.resolveStep, client.stepSchema, ['step1']);
+    await Reflect.apply(client.stepSchema.resolveStep, client.stepSchema, [
+      'step1',
+    ]);
 
     expect(client.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
       'ClientDefault',

--- a/packages/react/test/field.test.tsx
+++ b/packages/react/test/field.test.tsx
@@ -61,17 +61,19 @@ describe('Field', () => {
       },
     }).configure()();
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }) => (
-      <Field name='firstName' suspend fallback={<div>Loading</div>}>
-        {({ defaultValue, onInputChange }) => (
-          <input
-            data-testid='firstName'
-            value={defaultValue}
-            onChange={(event) => onInputChange(event.target.value)}
-          />
-        )}
-      </Field>
-    ));
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ Field }) => (
+        <Field name='firstName' suspend fallback={<div>Loading</div>}>
+          {({ defaultValue, onInputChange }) => (
+            <input
+              data-testid='firstName'
+              value={defaultValue}
+              onChange={(event) => onInputChange(event.target.value)}
+            />
+          )}
+        </Field>
+      ),
+    });
 
     const screen = await renderInJsdom(<Step1 />);
     const originalInput = screen.getByTestId('firstName') as HTMLInputElement;
@@ -121,68 +123,85 @@ describe('Field', () => {
       },
     }).configure()();
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }: any) => (
-      <>
-        <Field name='firstName'>
-          {({
-            defaultValue,
-            label,
-            name,
-            nameTransformCasing,
-            onInputChange,
-            reset,
-          }: any) => (
-            <div>
-              <p data-testid='name'>{name}</p>
-              <p data-testid='defaultValue'>{defaultValue}</p>
-              <p data-testid='label'>{label}</p>
-              <p data-testid='nameTransformCasing'>
-                {String(nameTransformCasing)}
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ Field }: any) => (
+        <>
+          <Field name='firstName'>
+            {({
+              defaultValue,
+              label,
+              name,
+              nameTransformCasing,
+              onInputChange,
+              reset,
+            }: any) => (
+              <div>
+                <p data-testid='name'>{name}</p>
+                <p data-testid='defaultValue'>{defaultValue}</p>
+                <p data-testid='label'>{label}</p>
+                <p data-testid='nameTransformCasing'>
+                  {String(nameTransformCasing)}
+                </p>
+                <button
+                  data-testid='update'
+                  onClick={() => onInputChange('Jo')}
+                >
+                  update
+                </button>
+                <button data-testid='reset' onClick={() => reset()}>
+                  reset
+                </button>
+              </div>
+            )}
+          </Field>
+
+          <Field
+            name='firstName'
+            selectorFn={(ctx: any) =>
+              ctx.step1.fields.firstName.defaultValue.length
+            }
+          >
+            {({ selected }: any) => (
+              <p data-testid='selectedValue'>{selected.value}</p>
+            )}
+          </Field>
+
+          <Field name='birthday'>
+            {({
+              defaultValue,
+              label,
+              name,
+              nameTransformCasing,
+              type,
+            }: any) => (
+              <div>
+                <p data-testid='dateName'>{name}</p>
+                <p data-testid='dateDefaultValue'>
+                  {defaultValue.toISOString()}
+                </p>
+                <p data-testid='dateLabel'>{label}</p>
+                <p data-testid='dateNameTransformCasing'>
+                  {nameTransformCasing}
+                </p>
+                <p data-testid='dateType'>{type}</p>
+              </div>
+            )}
+          </Field>
+
+          <Field name='middleName'>
+            {(props: any) => (
+              <p data-testid='disabledLabelHasProp'>
+                {String('label' in props)}
               </p>
-              <button data-testid='update' onClick={() => onInputChange('Jo')}>
-                update
-              </button>
-              <button data-testid='reset' onClick={() => reset()}>
-                reset
-              </button>
-            </div>
-          )}
-        </Field>
-
-        <Field
-          name='firstName'
-          selectorFn={(ctx: any) => ctx.step1.fields.firstName.defaultValue.length}
-        >
-          {({ selected }: any) => (
-            <p data-testid='selectedValue'>{selected.value}</p>
-          )}
-        </Field>
-
-        <Field name='birthday'>
-          {({ defaultValue, label, name, nameTransformCasing, type }: any) => (
-            <div>
-              <p data-testid='dateName'>{name}</p>
-              <p data-testid='dateDefaultValue'>{defaultValue.toISOString()}</p>
-              <p data-testid='dateLabel'>{label}</p>
-              <p data-testid='dateNameTransformCasing'>{nameTransformCasing}</p>
-              <p data-testid='dateType'>{type}</p>
-            </div>
-          )}
-        </Field>
-
-        <Field name='middleName'>
-          {(props: any) => (
-            <p data-testid='disabledLabelHasProp'>{String('label' in props)}</p>
-          )}
-        </Field>
-      </>
-    ));
-
-    schema.stepSchema.value.step1.createComponent(
-      ({ Field }) => (
-        <Field name='middleName'>{() => null}</Field>
+            )}
+          </Field>
+        </>
       ),
-    );
+    });
+
+    schema.stepSchema.value.step1.createComponent({
+      render: ({ Field }) => <Field name='middleName'>{() => null}</Field>,
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 
@@ -197,7 +216,9 @@ describe('Field', () => {
       'kebab',
     );
     expect(screen.getByTestId('dateType').textContent).toBe('date');
-    expect(screen.getByTestId('dateDefaultValue').textContent).toBe(date.toISOString());
+    expect(screen.getByTestId('dateDefaultValue').textContent).toBe(
+      date.toISOString(),
+    );
     expect(screen.getByTestId('disabledLabelHasProp').textContent).toBe(
       'false',
     );

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -905,3 +905,140 @@ describe('creating components via "createComponent" fn', () => {
     });
   });
 });
+
+describe('creating reusable components via "createComponent.forField"', () => {
+  it('creates a strongly typed, reactive step-specific field component', async () => {
+    const schema = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Contact',
+          fields: {
+            firstName: {
+              defaultValue: 'Taylor',
+              label: 'First name',
+              type: 'string.name',
+            },
+          },
+        },
+      },
+    }).configure()();
+
+    const FirstName = schema.stepSchema.value.step1.createComponent.forField({
+      field: 'firstName',
+      render(field, props: { prefix: string }) {
+        expectTypeOf(field.name).toEqualTypeOf<'firstName'>();
+        expectTypeOf(field.defaultValue).toEqualTypeOf<string>();
+        expectTypeOf(field.label).toEqualTypeOf<'First name'>();
+
+        return (
+          <button
+            data-testid='first-name'
+            onClick={() => field.onInputChange('Jordan')}
+          >
+            {props.prefix}: {field.defaultValue}
+          </button>
+        );
+      },
+    });
+
+    if (false) {
+      schema.stepSchema.value.step1.createComponent.forField({
+        // @ts-expect-error field names are restricted to the selected step.
+        field: 'age',
+        render: () => null,
+      });
+    }
+
+    const screen = await renderInJsdom(<FirstName prefix='Name' />);
+    const button = screen.getByTestId('first-name');
+
+    expect(button.textContent).toContain('Name: Taylor');
+
+    await act(async () => {
+      button.click();
+    });
+
+    expect(button.textContent).toContain('Name: Jordan');
+  });
+
+  it('supports the schema-level step and field selector', async () => {
+    const schema = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Contact',
+          fields: { firstName: { defaultValue: 'Taylor' } },
+        },
+        step2: {
+          title: 'Details',
+          fields: { age: { defaultValue: 30 } },
+        },
+      },
+    }).configure()();
+
+    const Age = schema.createComponent.forField({
+      step: 'step2',
+      field: 'age',
+      render(field) {
+        expectTypeOf(field.name).toEqualTypeOf<'age'>();
+        expectTypeOf(field.defaultValue).toEqualTypeOf<number>();
+
+        return <p>Age: {field.defaultValue}</p>;
+      },
+    });
+
+    if (false) {
+      schema.createComponent.forField({
+        step: 'step2',
+        // @ts-expect-error firstName belongs to step1, not step2.
+        field: 'firstName',
+        render: () => null,
+      });
+    }
+
+    const screen = await renderInJsdom(<Age />);
+
+    expect(screen.getByText('Age: 30')).toBeDefined();
+  });
+
+  it('reuses one configured-factory component across independent instances', async () => {
+    const createForm = defineMultiStepForm({
+      instances: ['client', 'admin'],
+      steps: {
+        step1: {
+          title: 'Contact',
+          fields: { firstName: { defaultValue: '' } },
+        },
+      },
+    }).configure();
+    const FirstName = createForm.createComponent.forField({
+      step: 'step1',
+      field: 'firstName',
+      render(field, props: { owner: string }) {
+        return (
+          <p>
+            {props.owner}: {field.defaultValue}
+          </p>
+        );
+      },
+    });
+
+    const client = createForm({ instance: 'client' });
+    client.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Client value',
+    });
+    createForm.setActiveInstance('client');
+    const clientScreen = await renderInJsdom(<FirstName owner='Client' />);
+
+    const admin = createForm({ instance: 'admin' });
+    admin.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Admin value',
+    });
+    createForm.setActiveInstance('admin');
+    const adminScreen = await renderInJsdom(<FirstName owner='Admin' />);
+
+    expect(clientScreen.getByText('Client: Client value')).toBeDefined();
+    expect(adminScreen.getByText('Admin: Admin value')).toBeDefined();
+  });
+});

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -1,5 +1,6 @@
 import type { MultiStepFormSchemaConfig } from '@/form-config';
 import {
+  InvalidComponentError,
   InvalidStepError,
   type StepNumbers,
   type StrippedResolvedStep,
@@ -83,6 +84,89 @@ async function renderInJsdom(ui: ReactElement) {
 }
 
 describe('creating components via "createComponent" fn', () => {
+  describe('using instance "createComponent" fn', () => {
+    it('provides the same single-step render input as the step factory', async () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Step 1',
+            fields: { firstName: { defaultValue: 'Taylor' } },
+          },
+        },
+      }).configure()();
+
+      const Step1 = schema.createComponent({
+        stepData: ['step1'],
+        render({
+          ctx,
+          Field,
+          Form,
+          Selector,
+          Suspend,
+          defaultValues,
+          onInputChange,
+          reset,
+          update,
+          useSelector,
+          useStep,
+        }) {
+          expectTypeOf(ctx.step1.title).toEqualTypeOf<string>();
+          expectTypeOf(defaultValues.firstName).toEqualTypeOf<string>();
+          expectTypeOf(Field).toBeFunction();
+          expectTypeOf(Form).toBeFunction();
+          expectTypeOf(Selector).toBeFunction();
+          expectTypeOf(Suspend).toBeFunction();
+          expectTypeOf(onInputChange).toBeFunction();
+          expectTypeOf(reset).toBeFunction();
+          expectTypeOf(update).toBeFunction();
+          expectTypeOf(useSelector).toBeFunction();
+          expectTypeOf(useStep).toBeFunction();
+
+          return (
+            <Field name='firstName'>
+              {({ defaultValue }) => (
+                <span data-testid='instance-field'>{defaultValue}</span>
+              )}
+            </Field>
+          );
+        },
+      });
+
+      const screen = await renderInJsdom(<Step1 />);
+
+      expect(screen.getByTestId('instance-field').textContent).toBe('Taylor');
+    });
+
+    it('only accepts an object with a render property', () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Step 1',
+            fields: { firstName: { defaultValue: '' } },
+          },
+        },
+      }).configure()();
+
+      if (false) {
+        // @ts-expect-error createComponent no longer accepts a callback argument.
+        schema.stepSchema.value.step1.createComponent(() => null);
+        // @ts-expect-error instance createComponent requires render in its config object.
+        schema.createComponent({ stepData: ['step1'] });
+      }
+
+      expect(() =>
+        Reflect.apply(
+          schema.stepSchema.value.step1.createComponent,
+          undefined,
+          [() => null],
+        ),
+      ).toThrow(InvalidComponentError);
+      expect(() =>
+        Reflect.apply(schema.createComponent, schema, [() => null]),
+      ).toThrow(InvalidComponentError);
+    });
+  });
+
   describe('using step specific "createComponent" fn', () => {
     it('should only use the default "ctx"', async () => {
       const schema = defineMultiStepForm({
@@ -142,7 +226,9 @@ describe('creating components via "createComponent" fn', () => {
         </div>
       ));
 
-      const Step1 = schema.stepSchema.value.step1.createComponent(componentSpy);
+      const Step1 = schema.stepSchema.value.step1.createComponent({
+        render: componentSpy,
+      });
 
       expect(Step1).toBeTypeOf('function');
 
@@ -214,12 +300,10 @@ describe('creating components via "createComponent" fn', () => {
           undefined
         >
       >(({ ctx }) => ({ step2: ctx.step2 }));
-      const Step1 = schema.stepSchema.value.step1.createComponent(
-        {
-          ctxData: ctxDataSpy,
-        },
-        componentSpy,
-      );
+      const Step1 = schema.stepSchema.value.step1.createComponent({
+        ctxData: ctxDataSpy,
+        render: componentSpy,
+      });
       console.log('-------------------after------------------');
       console.log(schema.stepSchema.value);
 
@@ -309,7 +393,9 @@ describe('creating components via "createComponent" fn', () => {
         </div>
       ));
 
-      const Step1 = schema.stepSchema.value.step1.createComponent(componentSpy);
+      const Step1 = schema.stepSchema.value.step1.createComponent({
+        render: componentSpy,
+      });
 
       expect(Step1).toBeTypeOf('function');
 
@@ -382,8 +468,8 @@ describe('creating components via "createComponent" fn', () => {
         });
 
         const spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => {
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => {
             spy(Form);
 
             return (
@@ -392,7 +478,7 @@ describe('creating components via "createComponent" fn', () => {
               </Form>
             );
           },
-        );
+        });
 
         const screen = await renderInJsdom(<Step1 />);
 
@@ -411,7 +497,9 @@ describe('creating components via "createComponent" fn', () => {
           },
         });
 
-        schema.stepSchema.value.step1.createComponent(({ Form }) => <Form />);
+        schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => <Form />,
+        });
       });
 
       it('keeps render context steps up to date', async () => {
@@ -434,9 +522,9 @@ describe('creating components via "createComponent" fn', () => {
             );
           },
         });
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => <Form />,
-        );
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => <Form />,
+        });
 
         const screen = await renderInJsdom(<Step1 />);
 
@@ -494,9 +582,9 @@ describe('creating components via "createComponent" fn', () => {
             }
 
             if (!currentStep.hasData) {
-              return currentStep.renderNoCurrentData({
-                className: 'no-current-data',
-              });
+              const NoCurrentData = currentStep.NoCurrentData;
+
+              return <NoCurrentData className='no-current-data' />;
             }
 
             expectTypeOf(
@@ -513,14 +601,14 @@ describe('creating components via "createComponent" fn', () => {
                 <span data-testid='callback-is-complete'>
                   {String(isStepComplete('step1'))}
                 </span>
-                {progress.renderProgressText({ className: 'progress-text' })}
+                <progress.ProgressText className='progress-text' />
               </div>
             );
           },
         });
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => <Form />,
-        );
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => <Form />,
+        });
 
         const screen = await renderInJsdom(<Step1 />);
 
@@ -550,9 +638,8 @@ describe('creating components via "createComponent" fn', () => {
 
         const schema = makeBaseSchema().withForm({
           render(context, { title, children }: CustomFormProps) {
-            type HasWidenedStepIndex = `step${number}` extends keyof typeof context.steps
-              ? true
-              : false;
+            type HasWidenedStepIndex =
+              `step${number}` extends keyof typeof context.steps ? true : false;
 
             expectTypeOf<HasWidenedStepIndex>().toEqualTypeOf<false>();
             expectTypeOf(
@@ -564,12 +651,12 @@ describe('creating components via "createComponent" fn', () => {
             expectTypeOf(
               context.steps.step1.fields.firstName.label,
             ).toEqualTypeOf<'First Name'>();
-            expectTypeOf(
-              context.steps.step1.isComplete,
-            ).toEqualTypeOf<() => boolean>();
-            expectTypeOf(context.isStepComplete).parameter(0).toEqualTypeOf<
-              'step1' | 'step2'
+            expectTypeOf(context.steps.step1.isComplete).toEqualTypeOf<
+              () => boolean
             >();
+            expectTypeOf(context.isStepComplete)
+              .parameter(0)
+              .toEqualTypeOf<'step1' | 'step2'>();
 
             // @ts-expect-error Only concrete schema step keys are accepted.
             context.isStepComplete('step3');
@@ -578,8 +665,8 @@ describe('creating components via "createComponent" fn', () => {
           },
         });
 
-        schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => {
+        schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => {
             const TypedForm = Form;
             expectTypeOf(TypedForm).toEqualTypeOf<
               (props: CustomFormProps) => ReactNode
@@ -590,7 +677,7 @@ describe('creating components via "createComponent" fn', () => {
 
             return <TypedForm title='typed-form'>content</TypedForm>;
           },
-        );
+        });
       });
 
       it('restores Form typing in CreateStepSpecificComponentCallback', () => {
@@ -623,7 +710,9 @@ describe('creating components via "createComponent" fn', () => {
           return <Form title='callback-typed-form'>content</Form>;
         };
 
-        const Step1 = schema.stepSchema.value.step1.createComponent(callback);
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: callback,
+        });
 
         expect(Step1).toBeTypeOf('function');
       });
@@ -664,13 +753,13 @@ describe('creating components via "createComponent" fn', () => {
           },
         });
 
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => (
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => (
             <Form>
               <span data-testid='form-inner-child'>child content</span>
             </Form>
           ),
-        );
+        });
 
         const screen = await renderInJsdom(<Step1 />);
 
@@ -687,8 +776,8 @@ describe('creating components via "createComponent" fn', () => {
         });
 
         const spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ MyForm }) => {
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ MyForm }) => {
             spy({ MyForm });
 
             return (
@@ -697,7 +786,7 @@ describe('creating components via "createComponent" fn', () => {
               </MyForm>
             );
           },
-        );
+        });
 
         const screen = await renderInJsdom(<Step1 />);
 
@@ -720,20 +809,20 @@ describe('creating components via "createComponent" fn', () => {
 
         const step1Spy = vi.fn();
         const step2Spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => {
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => {
             step1Spy(Form);
 
             return <Form data-testid='s1-form' />;
           },
-        );
-        const Step2 = schema.stepSchema.value.step2.createComponent(
-          ({ Form }) => {
+        });
+        const Step2 = schema.stepSchema.value.step2.createComponent({
+          render: ({ Form }) => {
             step2Spy(Form);
 
             return <Form data-testid='s2-form' />;
           },
-        );
+        });
 
         await renderInJsdom(<Step1 />);
         const step1LastCall = step1Spy.mock.lastCall;
@@ -755,17 +844,19 @@ describe('creating components via "createComponent" fn', () => {
         });
         const step1Spy = vi.fn();
         const step2Spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent(
-          ({ Form }) => {
+        const Step1 = schema.stepSchema.value.step1.createComponent({
+          render: ({ Form }) => {
             step1Spy(Form);
 
             return <Form />;
           },
-        );
-        const Step2 = schema.stepSchema.value.step2.createComponent((input) => {
-          step2Spy(input);
+        });
+        const Step2 = schema.stepSchema.value.step2.createComponent({
+          render: (input) => {
+            step2Spy(input);
 
-          return null;
+            return null;
+          },
         });
 
         await renderInJsdom(<Step1 />);
@@ -795,8 +886,8 @@ describe('creating components via "createComponent" fn', () => {
           }),
         });
 
-        schema.stepSchema.value.step1.createComponent(
-          ({ useStep, Suspend, Field }) => {
+        schema.stepSchema.value.step1.createComponent({
+          render: ({ useStep, Suspend, Field }) => {
             const { status } = useStep();
 
             status satisfies 'idle' | 'loading' | 'resolved' | 'error';
@@ -809,7 +900,7 @@ describe('creating components via "createComponent" fn', () => {
               </Suspend>
             );
           },
-        );
+        });
       });
     });
   });

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -907,7 +907,7 @@ describe('creating components via "createComponent" fn', () => {
 });
 
 describe('creating reusable components via "createComponent.forField"', () => {
-  it('creates a strongly typed, reactive step-specific field component', async () => {
+  it('creates a field component without custom props', async () => {
     const schema = defineMultiStepForm({
       steps: {
         step1: {
@@ -916,7 +916,6 @@ describe('creating reusable components via "createComponent.forField"', () => {
             firstName: {
               defaultValue: 'Taylor',
               label: 'First name',
-              type: 'string.name',
             },
           },
         },
@@ -925,49 +924,36 @@ describe('creating reusable components via "createComponent.forField"', () => {
 
     const FirstName = schema.stepSchema.value.step1.createComponent.forField({
       field: 'firstName',
-      render(field, props: { prefix: string }) {
+      render(field) {
         expectTypeOf(field.name).toEqualTypeOf<'firstName'>();
         expectTypeOf(field.defaultValue).toEqualTypeOf<string>();
-        expectTypeOf(field.label).toEqualTypeOf<'First name'>();
 
         return (
           <button
             data-testid='first-name'
             onClick={() => field.onInputChange('Jordan')}
           >
-            {props.prefix}: {field.defaultValue}
+            {field.defaultValue}
           </button>
         );
       },
     });
 
-    if (false) {
-      schema.stepSchema.value.step1.createComponent.forField({
-        // @ts-expect-error field names are restricted to the selected step.
-        field: 'age',
-        render: () => null,
-      });
-    }
-
-    const screen = await renderInJsdom(<FirstName prefix='Name' />);
+    const screen = await renderInJsdom(<FirstName suspend={false} />);
     const button = screen.getByTestId('first-name');
 
-    expect(button.textContent).toContain('Name: Taylor');
+    expect(button.textContent).toContain('Taylor');
 
     await act(async () => {
       button.click();
     });
 
-    expect(button.textContent).toContain('Name: Jordan');
+    expect(button.textContent).toContain('Jordan');
   });
 
-  it('supports the schema-level step and field selector', async () => {
+  it('creates a field component with custom props', async () => {
     const schema = defineMultiStepForm({
       steps: {
-        step1: {
-          title: 'Contact',
-          fields: { firstName: { defaultValue: 'Taylor' } },
-        },
         step2: {
           title: 'Details',
           fields: { age: { defaultValue: 30 } },
@@ -978,67 +964,20 @@ describe('creating reusable components via "createComponent.forField"', () => {
     const Age = schema.createComponent.forField({
       step: 'step2',
       field: 'age',
-      render(field) {
+      render(field, props: { suffix: string }) {
         expectTypeOf(field.name).toEqualTypeOf<'age'>();
         expectTypeOf(field.defaultValue).toEqualTypeOf<number>();
 
-        return <p>Age: {field.defaultValue}</p>;
-      },
-    });
-
-    if (false) {
-      schema.createComponent.forField({
-        step: 'step2',
-        // @ts-expect-error firstName belongs to step1, not step2.
-        field: 'firstName',
-        render: () => null,
-      });
-    }
-
-    const screen = await renderInJsdom(<Age />);
-
-    expect(screen.getByText('Age: 30')).toBeDefined();
-  });
-
-  it('reuses one configured-factory component across independent instances', async () => {
-    const createForm = defineMultiStepForm({
-      instances: ['client', 'admin'],
-      steps: {
-        step1: {
-          title: 'Contact',
-          fields: { firstName: { defaultValue: '' } },
-        },
-      },
-    }).configure();
-    const FirstName = createForm.createComponent.forField({
-      step: 'step1',
-      field: 'firstName',
-      render(field, props: { owner: string }) {
         return (
           <p>
-            {props.owner}: {field.defaultValue}
+            Age: {field.defaultValue} {props.suffix}
           </p>
         );
       },
     });
 
-    const client = createForm({ instance: 'client' });
-    client.stepSchema.value.step1.update({
-      fields: ['fields.firstName.defaultValue'],
-      updater: 'Client value',
-    });
-    createForm.setActiveInstance('client');
-    const clientScreen = await renderInJsdom(<FirstName owner='Client' />);
+    const screen = await renderInJsdom(<Age suffix='years' />);
 
-    const admin = createForm({ instance: 'admin' });
-    admin.stepSchema.value.step1.update({
-      fields: ['fields.firstName.defaultValue'],
-      updater: 'Admin value',
-    });
-    createForm.setActiveInstance('admin');
-    const adminScreen = await renderInJsdom(<FirstName owner='Admin' />);
-
-    expect(clientScreen.getByText('Client: Client value')).toBeDefined();
-    expect(adminScreen.getByText('Admin: Admin value')).toBeDefined();
+    expect(screen.getByText('Age: 30 years')).toBeDefined();
   });
 });

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -89,15 +89,15 @@ describe('step overrides', () => {
       step1: ({}) => deferred.promise,
     });
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(
-      ({ Field, Suspend }) => (
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ Field, Suspend }) => (
         <Suspend fallback={<p data-testid='loading'>Loading</p>}>
           <Field name='firstName'>
             {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
           </Field>
         </Suspend>
       ),
-    );
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 
@@ -137,20 +137,24 @@ describe('step overrides', () => {
       },
     });
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(({ Field }) => (
-      <Field
-        name='firstName'
-        suspend
-        fallback={<p data-testid='field-loading'>Loading field</p>}
-      >
-        {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
-      </Field>
-    ));
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ Field }) => (
+        <Field
+          name='firstName'
+          suspend
+          fallback={<p data-testid='field-loading'>Loading field</p>}
+        >
+          {({ defaultValue }) => <p data-testid='value'>{defaultValue}</p>}
+        </Field>
+      ),
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 
     expect(
-      Reflect.apply(schema.stepSchema.getStepStatus, schema.stepSchema, ['step1']),
+      Reflect.apply(schema.stepSchema.getStepStatus, schema.stepSchema, [
+        'step1',
+      ]),
     ).toBe('loading');
 
     await act(async () => {
@@ -187,8 +191,8 @@ describe('step overrides', () => {
       },
     });
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(
-      ({ useStep }) => {
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ useStep }) => {
         const { data, status } = useStep();
 
         return (
@@ -198,7 +202,7 @@ describe('step overrides', () => {
           </>
         );
       },
-    );
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 
@@ -231,8 +235,8 @@ describe('step overrides', () => {
     const firstNameRender = vi.fn();
     const contactDetailsRender = vi.fn();
 
-    const FirstName = schema.stepSchema.value.step1.createComponent(
-      ({ useStep }) => {
+    const FirstName = schema.stepSchema.value.step1.createComponent({
+      render: ({ useStep }) => {
         const firstName = useStep({
           selector: ({ data }) => data.fields.firstName.defaultValue,
         });
@@ -240,9 +244,9 @@ describe('step overrides', () => {
 
         return <p data-testid='selected-first-name'>{firstName}</p>;
       },
-    );
-    const ContactDetails = schema.stepSchema.value.step1.createComponent(
-      ({ useStep }) => {
+    });
+    const ContactDetails = schema.stepSchema.value.step1.createComponent({
+      render: ({ useStep }) => {
         const contactDetails = useStep({
           selector: ({ data }) => ({
             email: data.fields.email.defaultValue,
@@ -253,9 +257,9 @@ describe('step overrides', () => {
 
         return <p data-testid='contact-details'>{contactDetails.email}</p>;
       },
-    );
-    const Controls = schema.stepSchema.value.step1.createComponent(
-      ({ Field }) => (
+    });
+    const Controls = schema.stepSchema.value.step1.createComponent({
+      render: ({ Field }) => (
         <>
           <Field name='lastName'>
             {({ onInputChange }) => (
@@ -283,7 +287,7 @@ describe('step overrides', () => {
           </Field>
         </>
       ),
-    );
+    });
 
     const screen = await renderInJsdom(
       <>
@@ -335,8 +339,8 @@ describe('step overrides', () => {
     });
     const statusRender = vi.fn();
 
-    const Status = schema.stepSchema.value.step1.createComponent(
-      ({ useStep, Field }) => {
+    const Status = schema.stepSchema.value.step1.createComponent({
+      render: ({ useStep, Field }) => {
         const status = useStep({
           selector: (result) => result.status,
         });
@@ -356,12 +360,14 @@ describe('step overrides', () => {
           </>
         );
       },
-    );
+    });
 
     const screen = await renderInJsdom(<Status />);
 
     expect(
-      Reflect.apply(schema.stepSchema.getStepStatus, schema.stepSchema, ['step1']),
+      Reflect.apply(schema.stepSchema.getStepStatus, schema.stepSchema, [
+        'step1',
+      ]),
     ).toBe('loading');
 
     await act(async () => deferred.resolve({ firstName: 'Jordan' }));
@@ -402,8 +408,8 @@ describe('step overrides', () => {
       },
     });
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(
-      ({ Field, Suspend }) => (
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ Field, Suspend }) => (
         <Suspend fallback={<p data-testid='loading'>Loading</p>}>
           <Field name='firstName'>
             {({ defaultValue }) => (
@@ -417,7 +423,7 @@ describe('step overrides', () => {
           </Field>
         </Suspend>
       ),
-    );
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 
@@ -453,8 +459,8 @@ describe('step overrides', () => {
       },
     });
 
-    const Step1 = schema.stepSchema.value.step1.createComponent(
-      ({ useStep }) => {
+    const Step1 = schema.stepSchema.value.step1.createComponent({
+      render: ({ useStep }) => {
         const { error, status } = useStep();
 
         return (
@@ -466,7 +472,7 @@ describe('step overrides', () => {
           </>
         );
       },
-    );
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 
@@ -494,37 +500,41 @@ describe('step overrides', () => {
       },
     }).configure()();
 
-    schema.stepSchema.value.step1.createComponent(({ useStep }) => {
-      const defaultResult = useStep();
-      const undefinedSelectorResult = useStep(undefined);
-      const error = new CustomError('Failed to load step defaults');
-      const customResult = useStep({
-        error,
-      });
-      const firstName = useStep({
-        selector: ({ data }) => data.fields.firstName.defaultValue,
-      });
-      const status = useStep({
-        selector: (result) => result.status,
-      });
-      const customError = useStep({
-        error,
-        selector: (result) => result.error,
-      });
+    schema.stepSchema.value.step1.createComponent({
+      render: ({ useStep }) => {
+        const defaultResult = useStep();
+        const undefinedSelectorResult = useStep(undefined);
+        const error = new CustomError('Failed to load step defaults');
+        const customResult = useStep({
+          error,
+        });
+        const firstName = useStep({
+          selector: ({ data }) => data.fields.firstName.defaultValue,
+        });
+        const status = useStep({
+          selector: (result) => result.status,
+        });
+        const customError = useStep({
+          error,
+          selector: (result) => result.error,
+        });
 
-      expectTypeOf(
-        defaultResult.data.fields.firstName.defaultValue,
-      ).toEqualTypeOf<string>();
-      expectTypeOf(defaultResult.error).toEqualTypeOf<Error | undefined>();
-      expectTypeOf(
-        undefinedSelectorResult.data.fields.firstName.defaultValue,
-      ).toEqualTypeOf<string>();
-      expectTypeOf(customResult.error).toEqualTypeOf<CustomError | undefined>();
-      expectTypeOf(firstName).toEqualTypeOf<string>();
-      expectTypeOf(status).toEqualTypeOf<OverrideStatus>();
-      expectTypeOf(customError).toEqualTypeOf<CustomError | undefined>();
+        expectTypeOf(
+          defaultResult.data.fields.firstName.defaultValue,
+        ).toEqualTypeOf<string>();
+        expectTypeOf(defaultResult.error).toEqualTypeOf<Error | undefined>();
+        expectTypeOf(
+          undefinedSelectorResult.data.fields.firstName.defaultValue,
+        ).toEqualTypeOf<string>();
+        expectTypeOf(customResult.error).toEqualTypeOf<
+          CustomError | undefined
+        >();
+        expectTypeOf(firstName).toEqualTypeOf<string>();
+        expectTypeOf(status).toEqualTypeOf<OverrideStatus>();
+        expectTypeOf(customError).toEqualTypeOf<CustomError | undefined>();
 
-      return null;
+        return null;
+      },
     });
   });
 
@@ -551,9 +561,7 @@ describe('step overrides', () => {
     createForm().withOverrides({
       step1: ({ fields }) => {
         expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
-        expectTypeOf(
-          fields.phoneNumber.defaultValue,
-        ).toEqualTypeOf<string>();
+        expectTypeOf(fields.phoneNumber.defaultValue).toEqualTypeOf<string>();
         expectTypeOf(
           fields.saveToAccount.defaultValue,
         ).toEqualTypeOf<boolean>();
@@ -599,7 +607,10 @@ describe('step overrides', () => {
         },
       })
       .withForm({
-        render({ steps, isStepComplete }, props: ComponentPropsWithRef<'form'>) {
+        render(
+          { steps, isStepComplete },
+          props: ComponentPropsWithRef<'form'>,
+        ) {
           expectTypeOf(
             steps.step1.fields.firstName.defaultValue,
           ).toEqualTypeOf<string>();
@@ -612,8 +623,8 @@ describe('step overrides', () => {
       .withContext();
 
     const step1 = schema.stepSchema.value.step1;
-    const Step1 = step1.createComponent(
-      ({ Field, Form, Suspend }) => (
+    const Step1 = step1.createComponent({
+      render: ({ Field, Form, Suspend }) => (
         <Suspend fallback={<p data-testid='loading'>Loading</p>}>
           <Form>
             <Field name='firstName'>
@@ -629,7 +640,7 @@ describe('step overrides', () => {
           </Form>
         </Suspend>
       ),
-    );
+    });
 
     const screen = await renderInJsdom(<Step1 />);
 


### PR DESCRIPTION
## Summary

- restore the full schema surface on `defineMultiStepForm` definitions while preserving independent configured instance state
- expose exact step unions and schema helpers from definitions and configured factories
- align render-context helpers, progress components, and instance-level component arguments
- make `createComponent` consistently object-only through `{ render }`
- add strongly typed `createComponent.forField` factories with optional custom props and forwarded Field options
- update documentation and examples for the beta API

## Why

The beta definition and instance APIs had drifted apart: definitions no longer exposed all schema metadata, equivalent component factories accepted different arguments, and reusable field components could not be declared once and shared safely across independent instances. This made otherwise equivalent call sites behave and type-check differently.

These changes restore a consistent definition surface and component contract before the library leaves beta. Reusable components retain the schema shape while each configured instance keeps isolated state and subscriptions.

## Impact

`createComponent` now accepts only an options object containing `render`. Consumers of the previous callback overload must migrate to `{ render }`. New `forField` factories wrap the selected field internally, prevent callers from overriding `name` or `children`, forward other Field options, and infer optional custom render props through to component call sites.

The included changesets record the breaking beta contract restoration, the new field-component API, and the Field-prop forwarding fix.

## Validation

- full core and React test suites
- package TypeScript checks
- core and React package builds
- pre-commit validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major-version changesets and multiple breaking consumer contracts (`createComponent` signature, render-context helper names) across the public React and core definition surfaces.
> 
> **Overview**
> **Breaking beta API alignment** across core and React: `defineMultiStepForm` definitions now **extend the full schema** (`stepSchema`, React `withForm` / `createComponent`, etc.) with **state separate** from instances created via `.configure()`. A **type-only** `stepNumbers` union is available as `typeof definition.stepNumbers` (no runtime property).
> 
> **`createComponent`** only accepts an object with **`render`** (callback overload removed). Single-step `schema.createComponent({ stepData: ['step1'], render })` **delegates** to the step factory so render inputs match step-level components.
> 
> Adds **`createComponent.forField`** at schema, step, and configured-factory levels: field-bound reusable components with typed custom props, internal ownership of `name`/`children`, and **per-active-instance** binding on shared factories (WeakMap cache).
> 
> **Form render context** renames helpers to components: **`NoCurrentData`** and **`ProgressText`** (replacing `renderNoCurrentData` / `renderProgressText`). Field typing gains explicit **`boundProps`** with `targetStep` to avoid cross-step field name widening.
> 
> Docs, README, examples, and tests updated for the new shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d5405ed5a0732f72575976b45e100cd78fe73d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->