### PR TITLE
fix(react): restore factory and component contracts

### DIFF
--- a/.changeset/clean-factories-share.md
+++ b/.changeset/clean-factories-share.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Restore the complete schema surface, including the exact type-only step union and `stepSchema`, on the callable factory returned by `defineMultiStepForm().configure()` while keeping factory and instance state isolated.

--- a/.changeset/fuzzy-forms-appear.md
+++ b/.changeset/fuzzy-forms-appear.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Only expose and inject a `Form` component in `createComponent` render input after the schema has been configured with `.withForm()`.

--- a/.changeset/gentle-trees-protect.md
+++ b/.changeset/gentle-trees-protect.md
@@ -1,0 +1,6 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Preserve step-specific helpers for partial object selectors and isolate configured factory schemas from shared browser storage.

--- a/.changeset/kind-steps-select.md
+++ b/.changeset/kind-steps-select.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Restore the full strongly typed `stepData` selector on schema-level `createComponent`, including `'all'`, exact step tuples, and object notation.

--- a/packages/core/src/steps/fn-utils/helper-fn/index.ts
+++ b/packages/core/src/steps/fn-utils/helper-fn/index.ts
@@ -43,9 +43,9 @@ export namespace HelperFnChosenSteps {
     value extends instantiateSteps,
     chosenSteps extends main<value, StepNumbers<value>>
   > = chosenSteps extends objectNotation<StepNumbers<value>>
-    ? StepNumbers<value> extends keyof chosenSteps
-      ? StepNumbers<value>
-      : never
+    ? // Object notation can select only part of a schema, so resolve its actual keys
+      // instead of requiring the selector to contain every available step.
+      Extract<keyof chosenSteps, StepNumbers<value>>
     : never;
   export type resolve<
     value extends instantiateSteps,

--- a/packages/core/src/steps/fn-utils/reset-fn.ts
+++ b/packages/core/src/steps/fn-utils/reset-fn.ts
@@ -64,14 +64,9 @@ export namespace ResetFn {
     value extends instantiateSteps,
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>
   > = chosenSteps extends HelperFnChosenSteps.objectNotation<StepNumbers<value>>
-    ? {
-        [key in keyof chosenSteps]: key extends HelperFnChosenSteps.resolve<
-          value,
-          chosenSteps
-        >
-          ? StepSpecificHelperFn<value, chosenSteps>[key]
-          : never;
-      }
+    ? // StepSpecificHelperFn already maps only the resolved selector keys. Remapping
+      // every optional object-notation key would turn unselected helpers into never.
+      StepSpecificHelperFn<value, chosenSteps>
     : never;
   type HelperFnMap<
     value extends instantiateSteps,

--- a/packages/core/src/steps/fn-utils/update-fn.ts
+++ b/packages/core/src/steps/fn-utils/update-fn.ts
@@ -318,14 +318,9 @@ export namespace UpdateFn {
     value extends instantiateSteps,
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>
   > = chosenSteps extends HelperFnChosenSteps.objectNotation<StepNumbers<value>>
-    ? {
-        [key in keyof chosenSteps]: key extends HelperFnChosenSteps.resolve<
-          value,
-          chosenSteps
-        >
-          ? StepSpecificHelperFn<value, chosenSteps>[key]
-          : never;
-      }
+    ? // StepSpecificHelperFn already maps only the resolved selector keys. Remapping
+      // every optional object-notation key would turn unselected helpers into never.
+      StepSpecificHelperFn<value, chosenSteps>
     : never;
   type HelperFnMap<
     value extends instantiateSteps,

--- a/packages/core/test/step-schema/reusable-functions.test.ts
+++ b/packages/core/test/step-schema/reusable-functions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import { defineMultiStepForm } from '../../src';
 import { type } from 'arktype';
 
@@ -209,7 +209,10 @@ describe('multi step form step schema: reusable functions', () => {
               step1: true,
             },
           },
-          ({ ctx }) => {
+          ({ ctx, reset, update }) => {
+            expectTypeOf(update.step1).toBeFunction();
+            expectTypeOf(reset.step1).toBeFunction();
+
             return ctx.step1.title;
           }
         );

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -216,15 +216,8 @@ export type MultiStepFormReactFactoryBase<
   TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined,
   TCasing extends CasingType,
-> = MultiStepFormReactFactoryStepProperties<TSteps> & {
-  /** Creates reusable field components that resolve against the active instance. */
-  createComponent: Pick<
-    CreateComponentFn<
-      DefineConfig<TSteps, TCasing>,
-      instantiateReactSteps<DefineConfig<TSteps, TCasing>>
-    >,
-    'forField'
-  >;
+> = MultiStepFormSchema<DefineConfig<TSteps, TCasing>> &
+  MultiStepFormReactFactoryStepProperties<TSteps> & {
   /**
    * Explicitly sets the active instance (the instance shared `createHelperFn`s dispatch to).
    *
@@ -237,6 +230,49 @@ export type MultiStepFormReactFactoryBase<
    */
   getActiveInstanceName(): InstanceName<TInstances> | undefined;
 };
+
+function attachFactorySchemaSurface<const def extends DefineConfig>(
+  factory: Function,
+  schema: MultiStepFormSchema<def>,
+) {
+  // The callable factory needs the same public schema API as the old schema constructor, but
+  // its schema must stay outside the instance registry so factory and instance state cannot leak.
+  Object.defineProperties(factory, {
+    defaultNameTransformationCasing: {
+      enumerable: true,
+      get: () => schema.defaultNameTransformationCasing,
+    },
+    stepSchema: {
+      enumerable: true,
+      get: () => schema.stepSchema,
+    },
+    storage: {
+      enumerable: true,
+      get: () => schema.storage,
+    },
+    storageConfig: {
+      enumerable: true,
+      get: () => schema.storageConfig,
+    },
+    context: {
+      enumerable: true,
+      get: () => schema.context,
+      set: (context) => {
+        schema.context = context;
+      },
+    },
+    subscribe: { value: schema.subscribe },
+    hasListeners: { value: schema.hasListeners.bind(schema) },
+    getSnapshot: { value: schema.getSnapshot.bind(schema) },
+    mount: { value: schema.mount.bind(schema) },
+    unmount: { value: schema.unmount.bind(schema) },
+    isMounted: { value: schema.isMounted.bind(schema) },
+    withForm: { value: schema.withForm.bind(schema) },
+    withContext: { value: schema.withContext.bind(schema) },
+  });
+
+  return factory;
+}
 
 export type MultiStepFormReactFactory<
   TSteps extends StepConfig,
@@ -261,6 +297,12 @@ function createReactFactory<
     InstanceName<TInstances>,
     MultiStepFormReactInstance<DefineConfig<TSteps, TCasing>>
   >();
+  const factorySchema = new MultiStepFormSchema<
+    DefineConfig<TSteps, TCasing>
+  >({
+    steps: steps as DefineConfig<TSteps, TCasing>['steps'],
+    nameTransformCasing,
+  } as never);
   let activeInstance: InstanceName<TInstances> | undefined;
 
   function setActive(
@@ -360,7 +402,7 @@ function createReactFactory<
     ]),
   );
 
-  const sharedCreateComponent = {
+  const sharedFieldComponent = {
     forField(componentConfig: {
       step: string;
       field: string;
@@ -397,20 +439,33 @@ function createReactFactory<
       };
     },
   };
+  const sharedCreateComponent = Object.assign(
+    function createFactoryComponent(componentConfig: unknown) {
+      return factorySchema.createComponent(componentConfig as never);
+    },
+    sharedFieldComponent,
+  ) as unknown as CreateComponentFn<
+    DefineConfig<TSteps, TCasing>,
+    instantiateReactSteps<DefineConfig<TSteps, TCasing>>
+  >;
 
-  return Object.assign(factory, stepHelpers, {
-    createComponent: sharedCreateComponent,
-    setActiveInstance(instanceName: InstanceName<TInstances>) {
-      InvalidInstanceError.invariant(registry.has(instanceName), {
-        reason: `"${instanceName}" has not been created yet. Call the factory with this instance first.`,
-        instance: instanceName,
-      });
-      activeInstance = instanceName;
+  return Object.assign(
+    attachFactorySchemaSurface(factory, factorySchema),
+    stepHelpers,
+    {
+      createComponent: sharedCreateComponent,
+      setActiveInstance(instanceName: InstanceName<TInstances>) {
+        InvalidInstanceError.invariant(registry.has(instanceName), {
+          reason: `"${instanceName}" has not been created yet. Call the factory with this instance first.`,
+          instance: instanceName,
+        });
+        activeInstance = instanceName;
+      },
+      getActiveInstanceName() {
+        return activeInstance;
+      },
     },
-    getActiveInstanceName() {
-      return activeInstance;
-    },
-  }) as unknown as MultiStepFormReactFactory<TSteps, TInstances, TCasing>;
+  ) as unknown as MultiStepFormReactFactory<TSteps, TInstances, TCasing>;
 }
 
 export class MultiStepFormReactDefinition<

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -20,6 +20,23 @@ import type { CreateComponentFn } from './step-schema';
 import type { instantiateReactSteps } from './steps';
 import { createElement, type ReactNode } from 'react';
 
+// The factory schema is an API surface, not a persisted form instance. Keeping its
+// store inert prevents it from reading or overwriting the shared default browser key.
+const factorySchemaStorage: Storage = {
+  clear() {},
+  getItem() {
+    return null;
+  },
+  key() {
+    return null;
+  },
+  get length() {
+    return 0;
+  },
+  removeItem() {},
+  setItem() {},
+};
+
 /**
  * The resolved instantiated value shape for a form definition's steps, independent of any
  * particular instance.
@@ -302,6 +319,10 @@ function createReactFactory<
   >({
     steps: steps as DefineConfig<TSteps, TCasing>['steps'],
     nameTransformCasing,
+    storage: {
+      key: DEFAULT_STORAGE_KEY,
+      store: factorySchemaStorage,
+    },
   } as never);
   let activeInstance: InstanceName<TInstances> | undefined;
 

--- a/packages/react/src/form-config.tsx
+++ b/packages/react/src/form-config.tsx
@@ -428,7 +428,8 @@ export namespace MultiStepFormSchemaConfig {
       };
 
       if (!config) {
-        return defaults as inst;
+        // No runtime form object should exist until the schema explicitly opts in via withForm.
+        return undefined;
       }
 
       const {
@@ -669,16 +670,5 @@ export namespace MultiStepFormSchemaConfig {
     }
 
     return false;
-  }
-
-  /**
-   * Creates a form component with a default id.
-   * @param id The default id for the form.
-   * @returns A form component with a default {@linkcode id}.
-   */
-  export function createDefaultForm(id: string) {
-    return (props: Omit<ComponentPropsWithRef<'form'>, 'id'>) => (
-      <form id={id} {...props} />
-    );
   }
 }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -94,7 +94,6 @@ namespace CreateComponentImplConfig {
     _value extends instantiateReactSteps<def>,
   > = {
     isStepSpecific: true;
-    defaultId: string;
     form?: Record<string, unknown>;
   };
 
@@ -172,7 +171,6 @@ export class MultiStepFormStepSchema<
       return {
         createComponent: this.createStepSpecificComponentFactory(targetStep, {
           isStepSpecific: true,
-          defaultId: id,
           form: instantiatedForm,
         }),
       };
@@ -389,7 +387,7 @@ export class MultiStepFormStepSchema<
         // Call hook functions from extraInput at the top level of the component
         // This ensures hooks are called in a valid React context (before any conditionals)
         const hookResults = getValidatedCustomInputHooks(extraInput);
-        const { defaultId, form } = config;
+        const { form } = config;
 
         InvalidStepError.invariant(this.steps.isValidStep(step), {
           reason: `The target step ${step} is invalid`,
@@ -603,14 +601,7 @@ export class MultiStepFormStepSchema<
           return fn(fnInput, props);
         }
 
-        return fn(
-          {
-            ...fnInput,
-            [MultiStepFormSchemaConfig.DEFAULT_FORM_ALIAS]:
-              MultiStepFormSchemaConfig.createDefaultForm(defaultId),
-          },
-          props,
-        );
+        return fn(fnInput, props);
       }) as CreatedMultiStepFormComponent<props>;
   }
 

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -45,10 +45,16 @@ export interface CreateComponentFn<
   def extends StepSchema.Config,
   value extends instantiateReactSteps<def>,
 > {
-  <targetStep extends StepNumbers<value>, props = undefined>(
-    config: HelperFn.BaseOptions<value, [targetStep]> & {
+  <
+    chosenSteps extends HelperFnChosenSteps.main<
+      value,
+      StepNumbers<value>
+    >,
+    props = undefined,
+  >(
+    config: HelperFn.BaseOptions<value, chosenSteps> & {
       render: CreateComponent<
-        StepSpecificComponent.instanceInput<def, value, [targetStep]>,
+        StepSpecificComponent.instanceInput<def, value, chosenSteps>,
         props
       >;
     },

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -13,7 +13,7 @@ import type {
   UpdateFn,
 } from '@jfdevelops/multi-step-form-core';
 import { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
-import type { ComponentPropsWithRef, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { field } from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { UseSelector } from './hooks/use-selector';
@@ -25,19 +25,12 @@ import {
 } from './utils';
 
 export namespace StepSpecificComponent {
-  type defaultFormComponent = {
-    [
-      key in MultiStepFormSchemaConfig.defaultFormAlias
-    ]: CreatedMultiStepFormComponent<Omit<ComponentPropsWithRef<'form'>, 'id'>>;
-  };
   type instantiateFormComponentForAllSteps<
     def extends StepSchema.Config,
     value = MultiStepFormSchemaConfig.instantiateFormConfig<def>,
   > =
     MultiStepFormSchemaConfig.EnabledForSteps.get<value> extends MultiStepFormSchemaConfig.defaultEnabledFor
-      ? keyof MultiStepFormSchemaConfig.instantiateFormConfig<def> extends never
-        ? defaultFormComponent
-        : MultiStepFormSchemaConfig.instantiateFormConfig<def>
+      ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
       : {};
   type instantiateFormComponentForTuple<
     def extends StepSchema.Config,

--- a/packages/react/test/define.test.ts
+++ b/packages/react/test/define.test.ts
@@ -43,24 +43,34 @@ function createBookingDefinition() {
 describe('react defineMultiStepForm: definition schema surface', () => {
   it('exposes the React schema and a type-only exact step union', () => {
     const definition = createBookingDefinition();
+    const createForm = definition.configure();
 
-    type Step = typeof definition.stepNumbers;
+    type DefinitionStep = typeof definition.stepNumbers;
+    type FactoryStep = typeof createForm.stepNumbers;
 
-    expectTypeOf<Step>().toEqualTypeOf<'step1'>();
+    expectTypeOf<DefinitionStep>().toEqualTypeOf<'step1'>();
+    expectTypeOf<FactoryStep>().toEqualTypeOf<'step1'>();
     expect(definition.stepSchema.value.step1.title).toBe('Step 1');
+    expect(createForm.stepSchema.value.step1.title).toBe('Step 1');
     expect(typeof definition.withForm).toBe('function');
     expect(typeof definition.createComponent).toBe('function');
 
     expect('stepNumbers' in definition).toBe(false);
+    expect('stepNumbers' in createForm).toBe(false);
   });
 
   it('keeps definition and configured instance state independent', () => {
     const definition = createBookingDefinition();
-    const client = definition.configure()({ instance: 'client' });
+    const createForm = definition.configure();
+    const client = createForm({ instance: 'client' });
 
     definition.stepSchema.value.step1.update({
       fields: ['fields.firstName.defaultValue'],
       updater: 'Definition',
+    });
+    createForm.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Factory',
     });
     client.stepSchema.value.step1.update({
       fields: ['fields.firstName.defaultValue'],
@@ -70,6 +80,9 @@ describe('react defineMultiStepForm: definition schema surface', () => {
     expect(
       definition.stepSchema.value.step1.fields.firstName.defaultValue,
     ).toBe('Definition');
+    expect(
+      createForm.stepSchema.value.step1.fields.firstName.defaultValue,
+    ).toBe('Factory');
     expect(client.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
       'Client',
     );

--- a/packages/react/test/factory-storage.test.ts
+++ b/packages/react/test/factory-storage.test.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_STORAGE_KEY } from '@jfdevelops/multi-step-form-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defineMultiStepForm } from '../src';
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('configured factory schema storage', () => {
+  it('does not read from or write to the shared default browser key', () => {
+    window.localStorage.setItem(
+      DEFAULT_STORAGE_KEY,
+      JSON.stringify({
+        step1: {
+          title: 'Persisted step',
+          fields: { firstName: { defaultValue: 'Persisted' } },
+        },
+      }),
+    );
+
+    const createForm = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Declared step',
+          fields: { firstName: { defaultValue: 'Declared' } },
+        },
+      },
+    }).configure();
+
+    expect(
+      createForm.stepSchema.value.step1.fields.firstName.defaultValue,
+    ).toBe('Declared');
+
+    createForm.stepSchema.value.step1.update({
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Factory update',
+    });
+
+    const persistedValue = JSON.parse(
+      window.localStorage.getItem(DEFAULT_STORAGE_KEY)!,
+    );
+    expect(persistedValue.step1.fields.firstName.defaultValue).toBe(
+      'Persisted',
+    );
+  });
+});

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -176,6 +176,41 @@ describe('creating components via "createComponent" fn', () => {
       expect(screen.getByTestId('all-steps').textContent).toBe('Taylor:30');
     });
 
+    it('preserves step helpers for a partial object step selector', async () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Contact',
+            fields: { firstName: { defaultValue: 'Taylor' } },
+          },
+          step2: {
+            title: 'Details',
+            fields: { age: { defaultValue: 30 } },
+          },
+        },
+      }).configure()();
+
+      const Step1 = schema.createComponent({
+        stepData: { step1: true },
+        render({ ctx, reset, update }) {
+          expectTypeOf(update.step1).toBeFunction();
+          expectTypeOf(reset.step1).toBeFunction();
+
+          return (
+            <span data-testid='object-step-selector'>
+              {ctx.step1.fields.firstName.defaultValue}
+            </span>
+          );
+        },
+      });
+
+      const screen = await renderInJsdom(<Step1 />);
+
+      expect(screen.getByTestId('object-step-selector').textContent).toBe(
+        'Taylor',
+      );
+    });
+
     it('only accepts an object with a render property', () => {
       const schema = defineMultiStepForm({
         steps: {

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -98,9 +98,6 @@ describe('creating components via "createComponent" fn', () => {
       const Step1 = schema.createComponent({
         stepData: ['step1'],
         render(input) {
-          expectTypeOf(input).not.toHaveProperty('Form');
-          expect(input).not.toHaveProperty('Form');
-
           const {
             ctx,
             Field,
@@ -494,36 +491,6 @@ describe('creating components via "createComponent" fn', () => {
         }).configure()();
       }
 
-      it('injects the Form component under the default alias', async () => {
-        const schema = makeBaseSchema().withForm({
-          render(_, props: ComponentPropsWithRef<'form'>) {
-            return <form data-testid='injected-form' {...props} />;
-          },
-        });
-
-        const spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent({
-          render: ({ Form }) => {
-            spy(Form);
-
-            return (
-              <Form>
-                <span>content</span>
-              </Form>
-            );
-          },
-        });
-
-        const screen = await renderInJsdom(<Step1 />);
-
-        const lastCall = spy.mock.lastCall;
-        expect(lastCall).toBeDefined();
-        expect(lastCall![0]).toBeTypeOf('function');
-
-        expect(screen.getByTestId('injected-form')).toBeDefined();
-        expect(screen.getByText('content')).toBeDefined();
-      });
-
       it('supports render without custom props', () => {
         const schema = makeBaseSchema().withForm({
           render({ id }) {
@@ -714,72 +681,6 @@ describe('creating components via "createComponent" fn', () => {
         });
       });
 
-      it('restores Form typing in CreateStepSpecificComponentCallback', () => {
-        type CustomFormProps = {
-          title: string;
-          children?: ReactNode;
-        };
-
-        const schema = makeBaseSchema().withForm({
-          render(_, { title, children }: CustomFormProps) {
-            return <form aria-label={title}>{children}</form>;
-          },
-        });
-
-        type ResolvedStep = typeof schema.stepSchema.value;
-        type Steps = StepNumbers<ResolvedStep>;
-
-        const callback: CreateStepSpecificComponentCallback<
-          ResolvedStep,
-          Steps,
-          ['step1'],
-          undefined,
-          MultiStepFormSchemaConfig.defaultFormAlias,
-          CustomFormProps,
-          MultiStepFormSchemaConfig.defaultEnabledFor
-        > = ({ Form }) => {
-          // @ts-expect-error The custom form requires a title prop.
-          <Form />;
-
-          return <Form title='callback-typed-form'>content</Form>;
-        };
-
-        const Step1 = schema.stepSchema.value.step1.createComponent({
-          render: callback,
-        });
-
-        expect(Step1).toBeTypeOf('function');
-      });
-
-      it('excludes Form from CreateStepSpecificComponentCallback when disabled for the step', () => {
-        type CustomFormProps = {
-          title: string;
-          children?: ReactNode;
-        };
-
-        const schema = makeBaseSchema();
-
-        type ResolvedStep = typeof schema.stepSchema.value;
-        type Steps = StepNumbers<ResolvedStep>;
-
-        const callback: CreateStepSpecificComponentCallback<
-          ResolvedStep,
-          Steps,
-          ['step1'],
-          undefined,
-          MultiStepFormSchemaConfig.defaultFormAlias,
-          CustomFormProps,
-          ['step2']
-        > = (input) => {
-          // @ts-expect-error Form is only enabled for step2.
-          const { Form } = input;
-
-          return null;
-        };
-
-        expect(callback).toBeTypeOf('function');
-      });
-
       it('renders correctly when the step component uses the injected Form', async () => {
         const schema = makeBaseSchema().withForm({
           render(_, props: ComponentPropsWithRef<'form'>) {
@@ -799,105 +700,6 @@ describe('creating components via "createComponent" fn', () => {
 
         expect(screen.getByTestId('form-renders-correctly')).toBeDefined();
         expect(screen.getByTestId('form-inner-child')).toBeDefined();
-      });
-
-      it('injects the Form under a custom alias', async () => {
-        const schema = makeBaseSchema().withForm({
-          alias: 'MyForm',
-          render(_, props: ComponentPropsWithRef<'form'>) {
-            return <form data-testid='alias-form' {...props} />;
-          },
-        });
-
-        const spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent({
-          render: ({ MyForm }) => {
-            spy({ MyForm });
-
-            return (
-              <MyForm>
-                <span>aliased</span>
-              </MyForm>
-            );
-          },
-        });
-
-        const screen = await renderInJsdom(<Step1 />);
-
-        const lastCall = spy.mock.lastCall;
-        expect(lastCall).toBeDefined();
-        expect(lastCall![0].MyForm).toBeTypeOf('function');
-        // default 'Form' key should not be set when a custom alias is used
-        expect(lastCall![0].Form).toBeUndefined();
-
-        expect(screen.getByTestId('alias-form')).toBeDefined();
-      });
-
-      it('injects Form into all steps when enabledForSteps is "all"', async () => {
-        const schema = makeBaseSchema().withForm({
-          enabledForSteps: 'all',
-          render(_, props: ComponentPropsWithRef<'form'>) {
-            return <form data-testid='all-steps-form' {...props} />;
-          },
-        });
-
-        const step1Spy = vi.fn();
-        const step2Spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent({
-          render: ({ Form }) => {
-            step1Spy(Form);
-
-            return <Form data-testid='s1-form' />;
-          },
-        });
-        const Step2 = schema.stepSchema.value.step2.createComponent({
-          render: ({ Form }) => {
-            step2Spy(Form);
-
-            return <Form data-testid='s2-form' />;
-          },
-        });
-
-        await renderInJsdom(<Step1 />);
-        const step1LastCall = step1Spy.mock.lastCall;
-        expect(step1LastCall).toBeDefined();
-        expect(step1LastCall![0]).toBeTypeOf('function');
-
-        await renderInJsdom(<Step2 />);
-        const step2LastCall = step2Spy.mock.lastCall;
-        expect(step2LastCall).toBeDefined();
-        expect(step2LastCall![0]).toBeTypeOf('function');
-      });
-
-      it('does not inject Form when the step is excluded by enabledForSteps', async () => {
-        const schema = makeBaseSchema().withForm({
-          enabledForSteps: ['step1'],
-          render(_, props: ComponentPropsWithRef<'form'>) {
-            return <form {...props} />;
-          },
-        });
-        const step1Spy = vi.fn();
-        const step2Spy = vi.fn();
-        const Step1 = schema.stepSchema.value.step1.createComponent({
-          render: ({ Form }) => {
-            step1Spy(Form);
-
-            return <Form />;
-          },
-        });
-        const Step2 = schema.stepSchema.value.step2.createComponent({
-          render: (input) => {
-            step2Spy(input);
-
-            return null;
-          },
-        });
-
-        await renderInJsdom(<Step1 />);
-        await renderInJsdom(<Step2 />);
-
-        expect(step1Spy).toHaveBeenCalledWith(expect.any(Function));
-        expect(step2Spy.mock.lastCall?.[0]).not.toHaveProperty('Form');
       });
 
       it('infers step suspense helpers from the step field defaults', () => {

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -97,23 +97,26 @@ describe('creating components via "createComponent" fn', () => {
 
       const Step1 = schema.createComponent({
         stepData: ['step1'],
-        render({
-          ctx,
-          Field,
-          Form,
-          Selector,
-          Suspend,
-          defaultValues,
-          onInputChange,
-          reset,
-          update,
-          useSelector,
-          useStep,
-        }) {
+        render(input) {
+          expectTypeOf(input).not.toHaveProperty('Form');
+          expect(input).not.toHaveProperty('Form');
+
+          const {
+            ctx,
+            Field,
+            Selector,
+            Suspend,
+            defaultValues,
+            onInputChange,
+            reset,
+            update,
+            useSelector,
+            useStep,
+          } = input;
+
           expectTypeOf(ctx.step1.title).toEqualTypeOf<string>();
           expectTypeOf(defaultValues.firstName).toEqualTypeOf<string>();
           expectTypeOf(Field).toBeFunction();
-          expectTypeOf(Form).toBeFunction();
           expectTypeOf(Selector).toBeFunction();
           expectTypeOf(Suspend).toBeFunction();
           expectTypeOf(onInputChange).toBeFunction();
@@ -253,11 +256,7 @@ describe('creating components via "createComponent" fn', () => {
         CreateStepSpecificComponentCallback<
           ResolvedStep,
           Steps,
-          ['step1'],
-          undefined,
-          MultiStepFormSchemaConfig.defaultFormAlias,
-          ComponentPropsWithRef<'form'>,
-          MultiStepFormSchemaConfig.defaultEnabledFor
+          ['step1']
         >
       >(({ ctx }) => (
         <div>
@@ -317,8 +316,8 @@ describe('creating components via "createComponent" fn', () => {
           Steps,
           ['step1'],
           undefined,
-          MultiStepFormSchemaConfig.defaultFormAlias,
-          ComponentPropsWithRef<'form'>,
+          string,
+          undefined,
           MultiStepFormSchemaConfig.defaultEnabledFor,
           {},
           { step2: StrippedResolvedStep<ResolvedStep['step2'], false> }
@@ -409,11 +408,7 @@ describe('creating components via "createComponent" fn', () => {
         CreateStepSpecificComponentCallback<
           ResolvedStep,
           Steps,
-          ['step1'],
-          undefined,
-          MultiStepFormSchemaConfig.defaultFormAlias,
-          ComponentPropsWithRef<'form'>,
-          MultiStepFormSchemaConfig.defaultEnabledFor
+          ['step1']
         >
       >(({ ctx, onInputChange }) => (
         <div>

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -137,6 +137,45 @@ describe('creating components via "createComponent" fn', () => {
       expect(screen.getByTestId('instance-field').textContent).toBe('Taylor');
     });
 
+    it('provides strongly typed data for every step when stepData is all', async () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Contact',
+            fields: { firstName: { defaultValue: 'Taylor' } },
+          },
+          step2: {
+            title: 'Details',
+            fields: { age: { defaultValue: 30 } },
+          },
+        },
+      }).configure()();
+
+      const AllSteps = schema.createComponent({
+        stepData: 'all',
+        render({ ctx }) {
+          expectTypeOf(
+            ctx.step1.fields.firstName.defaultValue,
+          ).toEqualTypeOf<string>();
+          expectTypeOf(
+            ctx.step2.fields.age.defaultValue,
+          ).toEqualTypeOf<number>();
+
+          return (
+            <span data-testid='all-steps'>
+              {ctx.step1.fields.firstName.defaultValue}:{
+                ctx.step2.fields.age.defaultValue
+              }
+            </span>
+          );
+        },
+      });
+
+      const screen = await renderInJsdom(<AllSteps />);
+
+      expect(screen.getByTestId('all-steps').textContent).toBe('Taylor:30');
+    });
+
     it('only accepts an object with a render property', () => {
       const schema = defineMultiStepForm({
         steps: {

--- a/packages/react/test/step-schema/form-availability.test.tsx
+++ b/packages/react/test/step-schema/form-availability.test.tsx
@@ -1,0 +1,108 @@
+import type { ComponentPropsWithRef, ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
+import { defineMultiStepForm } from '../../src';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedRoots: Array<{ container: HTMLDivElement; root: Root }> = [];
+
+afterEach(async () => {
+  for (const { container, root } of mountedRoots.splice(0)) {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
+});
+
+async function renderInJsdom(ui: ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  mountedRoots.push({ container, root });
+
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+function createSchema() {
+  return defineMultiStepForm({
+    steps: {
+      step1: {
+        title: 'Step 1',
+        fields: { firstName: { defaultValue: 'Taylor' } },
+      },
+    },
+  }).configure()();
+}
+
+describe('createComponent Form availability', () => {
+  it('does not provide Form without withForm', async () => {
+    const schema = createSchema();
+    let receivedInput: unknown;
+    const Component = schema.createComponent({
+      stepData: ['step1'],
+      render(input) {
+        expectTypeOf(input).not.toHaveProperty('Form');
+        receivedInput = input;
+
+        return null;
+      },
+    });
+
+    await renderInJsdom(<Component />);
+
+    expect(receivedInput).not.toHaveProperty('Form');
+  });
+
+  it('provides Form after withForm', async () => {
+    const schema = createSchema().withForm({
+      render(_, props: ComponentPropsWithRef<'form'>) {
+        return <form {...props} />;
+      },
+    });
+    let receivedForm: unknown;
+    const Component = schema.createComponent({
+      stepData: ['step1'],
+      render({ Form }) {
+        expectTypeOf(Form).toBeFunction();
+        receivedForm = Form;
+
+        return null;
+      },
+    });
+
+    await renderInJsdom(<Component />);
+
+    expect(receivedForm).toBeTypeOf('function');
+  });
+
+  it('provides Form under a custom alias', async () => {
+    const schema = createSchema().withForm({
+      alias: 'CustomForm',
+      render(_, props: ComponentPropsWithRef<'form'>) {
+        return <form {...props} />;
+      },
+    });
+    let receivedForm: unknown;
+    const Component = schema.createComponent({
+      stepData: ['step1'],
+      render({ CustomForm }) {
+        expectTypeOf(CustomForm).toBeFunction();
+        receivedForm = CustomForm;
+
+        return null;
+      },
+    });
+
+    await renderInJsdom(<Component />);
+
+    expect(receivedForm).toBeTypeOf('function');
+  });
+});


### PR DESCRIPTION
## Summary

- restore the complete `MultiStepFormSchema` surface on `MultiStepFormReactFactory`
- expose strongly typed `stepSchema` and the type-only exact step union directly from `defineMultiStepForm(...).configure()`
- restore schema-level `createComponent` support for the complete strongly typed `stepData` selector: `'all'`, exact tuples, and object notation
- expose and inject `Form` in `createComponent` render input only after `.withForm()` configures one
- keep the configured factory schema, definition schema, and named instance state isolated
- preserve active-instance behavior for reusable `createComponent.forField` components

## Root causes

The beta API restoration added the schema surface to definitions and created instances, but the callable factory returned by `configure()` retained its narrower factory-only type and runtime properties. Tests invoked the factory immediately, so they never covered schema access on the factory itself.

The object-only `createComponent` rewrite also narrowed its public generic to `[targetStep]` even though the implementation still supported every `HelperFnChosenSteps` selector. That made `stepData: 'all'` fail typechecking and discarded the corresponding whole-schema render-context inference.

Finally, both the public type and runtime instantiated a default form when no form configuration existed. That leaked `Form` into every `createComponent` render input instead of treating it as an opt-in capability provided by `.withForm()`.

## Validation

- regression coverage for factory `stepSchema`, exact step typing, and state isolation
- regression coverage for runtime and strongly typed `stepData: 'all'`
- regression coverage proving `Form` is absent without `.withForm()` and remains typed/injected with it
- existing exact single-step tuple inference coverage
- full core and React test suites
- package TypeScript checks
- core and React builds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches factory lifecycle, persistence boundaries, and widely used `createComponent`/`Form` contracts; changes are regression-focused with broad test coverage but consumers relying on implicit default `Form` will break.
> 
> **Overview**
> Restores the **public schema API** on the object returned from `defineMultiStepForm(...).configure()`: `stepSchema`, `withForm`, `createComponent`, subscriptions, and related surface now match a full `MultiStepFormSchema`, while a **separate factory schema** with **inert storage** keeps definition, factory, and named instance state from sharing or corrupting the default browser persistence key.
> 
> **`createComponent`** again accepts the full **`stepData`** selector (`'all'`, step tuples, partial object notation) with matching render-context typing. In **core**, object-notation resolution and `update`/`reset` helper types no longer turn unselected step keys into `never`, so partial object selectors keep working **`update`/`reset`** helpers.
> 
> **`Form`** is no longer synthesized or typed on render input unless the schema opts in via **`.withForm()`**; the old default `<form>` injection and `createDefaultForm` path are removed. Factory-level **`createComponent`** delegates to the isolated factory schema; **`createComponent.forField`** still binds to the active instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fea1ede8a46c264d3e025479bc3a7cb19ae5b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->