### PR TITLE
feat(react): bind shared fields to explicit instances

### DIFF
--- a/.changeset/sharp-fields-select.md
+++ b/.changeset/sharp-fields-select.md
@@ -1,0 +1,13 @@
+---
+'@jfdevelops/react-multi-step-form': major
+---
+
+Require reusable field components created from configured factories to receive the form instance they render against, preventing shared components from reading whichever instance was most recently active.
+
+Allow `createComponent.forField` to omit its configured field and return a reusable component with a required, strongly typed `field` prop for selecting any field in the target step.
+
+Restore React render utilities for components selecting multiple steps or all steps, including configured form aliases and reactive selectors. These components now expose documented `defaultValues.grouped` and `defaultValues.flat` views.
+
+Preserve duplicate field names in `defaultValues.flat` by grouping their values under the selected step keys instead of overwriting an earlier step.
+
+Expose `Field` to components selecting multiple steps or all steps, using qualified names such as `step1.firstName` to route field subscriptions, suspense, updates, and resets without ambiguity.

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -9,6 +9,11 @@ import {
   type DefaultCasing,
   type DefineConfig,
   type DefineMultiStepFormOptions,
+  type Expand,
+  type getDeepFields,
+  type HelperFn,
+  type HelperFnChosenSteps,
+  InvalidComponentError,
   type InstanceName,
   type StepConfig,
   type StepNumbers,
@@ -16,8 +21,14 @@ import {
   type WithOverridesMap,
 } from '@jfdevelops/multi-step-form-core';
 import { MultiStepFormSchema } from './schema';
-import type { CreateComponentFn } from './step-schema';
-import type { instantiateReactSteps } from './steps';
+import {
+  type instantiateReactSteps,
+  type StepSpecificComponent,
+} from './steps';
+import type {
+  CreateComponent,
+  CreatedMultiStepFormComponent,
+} from './utils';
 import { createElement, type ReactNode } from 'react';
 
 // The factory schema is an API surface, not a persisted form instance. Keeping its
@@ -41,10 +52,10 @@ const factorySchemaStorage: Storage = {
  * The resolved instantiated value shape for a form definition's steps, independent of any
  * particular instance.
  */
-export type DefineReactValue<TSteps extends StepConfig> =
-  instantiateReactSteps<{
-    steps: TSteps;
-  }>;
+export type DefineReactValue<
+  TSteps extends StepConfig,
+  TCasing extends CasingType = DefaultCasing,
+> = instantiateReactSteps<DefineConfig<TSteps, TCasing>>;
 
 export interface MultiStepFormReactInstance<
   def extends DefineConfig,
@@ -222,6 +233,193 @@ export interface MultiStepFormReactFactoryStepFunctions<
   createHelperFn: StepSpecificHelperFn<DefineReactValue<TSteps>, key>;
 }
 
+type FactoryFieldComponentProps<
+  TSteps extends StepConfig,
+  TCasing extends CasingType,
+  targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
+  targetField extends getDeepFields<
+    DefineReactValue<TSteps, TCasing>,
+    targetStep
+  >,
+  customProps extends object,
+  selectable extends boolean,
+> = Expand<
+  (selectable extends true
+    ? StepSpecificComponent.selectableFieldComponentProps<
+        DefineConfig<TSteps, TCasing>,
+        DefineReactValue<TSteps, TCasing>,
+        targetStep,
+        targetField,
+        customProps
+      >
+    : StepSpecificComponent.fieldComponentProps<
+        DefineConfig<TSteps, TCasing>,
+        DefineReactValue<TSteps, TCasing>,
+        targetStep,
+        targetField,
+        customProps
+      >) & {
+    /** The configured form instance whose state and overrides this component reads. */
+    instance: MultiStepFormReactInstance<DefineConfig<TSteps, TCasing>>;
+  }
+>;
+
+interface MultiStepFormReactFactoryCreateComponentFn<
+  TSteps extends StepConfig,
+  TCasing extends CasingType,
+> {
+  <
+    chosenSteps extends HelperFnChosenSteps.main<
+      DefineReactValue<TSteps, TCasing>,
+      StepNumbers<DefineReactValue<TSteps, TCasing>>
+    >,
+    props = undefined,
+  >(
+    config: HelperFn.BaseOptions<
+      DefineReactValue<TSteps, TCasing>,
+      chosenSteps
+    > & {
+      render: CreateComponent<
+        StepSpecificComponent.instanceInput<
+          DefineConfig<TSteps, TCasing>,
+          DefineReactValue<TSteps, TCasing>,
+          chosenSteps
+        >,
+        props
+      >;
+    },
+  ): CreatedMultiStepFormComponent<props>;
+
+  forField<
+    targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
+    targetField extends getDeepFields<
+      DefineReactValue<TSteps, TCasing>,
+      targetStep
+    >,
+    customProps extends object = {},
+  >(
+    config: StepSpecificComponent.fieldConfig<
+      DefineConfig<TSteps, TCasing>,
+      DefineReactValue<TSteps, TCasing>,
+      targetStep,
+      targetField,
+      customProps
+    > & { step: targetStep },
+  ): (
+    props: FactoryFieldComponentProps<
+      TSteps,
+      TCasing,
+      targetStep,
+      targetField,
+      customProps,
+      false
+    >,
+  ) => ReactNode;
+
+  forField<
+    targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
+    customProps extends object = {},
+  >(
+    config: StepSpecificComponent.selectableFieldConfig<
+      DefineConfig<TSteps, TCasing>,
+      DefineReactValue<TSteps, TCasing>,
+      targetStep,
+      getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
+      customProps
+    > & { step: targetStep },
+  ): (
+    props: FactoryFieldComponentProps<
+      TSteps,
+      TCasing,
+      targetStep,
+      getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
+      customProps,
+      true
+    >,
+  ) => ReactNode;
+}
+
+interface MultiStepFormReactFactoryStepCreateComponentFn<
+  TSteps extends StepConfig,
+  TCasing extends CasingType,
+  targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
+> {
+  <additionalCtx extends Record<string, unknown> = {}, props = undefined>(
+    config: StepSpecificComponent.config<
+      DefineConfig<TSteps, TCasing>,
+      DefineReactValue<TSteps, TCasing>,
+      targetStep,
+      props,
+      additionalCtx
+    >,
+  ): CreatedMultiStepFormComponent<props>;
+
+  forField<
+    targetField extends getDeepFields<
+      DefineReactValue<TSteps, TCasing>,
+      targetStep
+    >,
+    customProps extends object = {},
+  >(
+    config: StepSpecificComponent.fieldConfig<
+      DefineConfig<TSteps, TCasing>,
+      DefineReactValue<TSteps, TCasing>,
+      targetStep,
+      targetField,
+      customProps
+    >,
+  ): (
+    props: FactoryFieldComponentProps<
+      TSteps,
+      TCasing,
+      targetStep,
+      targetField,
+      customProps,
+      false
+    >,
+  ) => ReactNode;
+
+  forField<customProps extends object = {}>(
+    config: StepSpecificComponent.selectableFieldConfig<
+      DefineConfig<TSteps, TCasing>,
+      DefineReactValue<TSteps, TCasing>,
+      targetStep,
+      getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
+      customProps
+    >,
+  ): (
+    props: FactoryFieldComponentProps<
+      TSteps,
+      TCasing,
+      targetStep,
+      getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
+      customProps,
+      true
+    >,
+  ) => ReactNode;
+}
+
+type MultiStepFormReactFactoryStepSchema<
+  TSteps extends StepConfig,
+  TCasing extends CasingType,
+> = Omit<
+  MultiStepFormSchema<DefineConfig<TSteps, TCasing>>['stepSchema'],
+  'value'
+> & {
+  value: {
+    [targetStep in StepNumbers<DefineReactValue<TSteps, TCasing>>]: Omit<
+      DefineReactValue<TSteps, TCasing>[targetStep],
+      'createComponent'
+    > & {
+      createComponent: MultiStepFormReactFactoryStepCreateComponentFn<
+        TSteps,
+        TCasing,
+        targetStep
+      >;
+    };
+  };
+};
+
 export type MultiStepFormReactFactoryStepProperties<TSteps extends StepConfig> =
   {
     [
@@ -233,8 +431,13 @@ export type MultiStepFormReactFactoryBase<
   TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined,
   TCasing extends CasingType,
-> = MultiStepFormSchema<DefineConfig<TSteps, TCasing>> &
+> = Omit<
+  MultiStepFormSchema<DefineConfig<TSteps, TCasing>>,
+  'createComponent' | 'stepSchema'
+> &
   MultiStepFormReactFactoryStepProperties<TSteps> & {
+  createComponent: MultiStepFormReactFactoryCreateComponentFn<TSteps, TCasing>;
+  stepSchema: MultiStepFormReactFactoryStepSchema<TSteps, TCasing>;
   /**
    * Explicitly sets the active instance (the instance shared `createHelperFn`s dispatch to).
    *
@@ -426,24 +629,39 @@ function createReactFactory<
   const sharedFieldComponent = {
     forField(componentConfig: {
       step: string;
-      field: string;
+      field?: string;
       render: (field: unknown, props: unknown) => ReactNode;
     }) {
-      // Each active instance gets its own bound component. Caching preserves component identity
-      // and subscriptions when the shared component is reused across independently stored forms.
+      // Each explicitly selected instance gets its own bound component. Caching preserves
+      // component identity and subscriptions without relying on mutable global selection.
       const components = new WeakMap<object, (props?: unknown) => ReactNode>();
 
       return (props?: unknown) => {
-        const active = getActiveInstance();
-        let Component = components.get(active);
+        InvalidComponentError.invariant(
+          typeof props === 'object' &&
+            props !== null &&
+            'instance' in props,
+          {
+            reason:
+              'A shared field component requires an "instance" prop containing the configured form instance it should use',
+            component: 'createFieldComponent',
+            argument: 'props.instance',
+            value: props,
+          },
+        );
+
+        const { instance, ...componentProps } = props as {
+          instance: MultiStepFormReactInstance<DefineConfig<TSteps, TCasing>>;
+        } & Record<string, unknown>;
+        let Component = components.get(instance);
 
         if (!Component) {
-          const step = (active.stepSchema.value as Record<string, unknown>)[
+          const step = (instance.stepSchema.value as Record<string, unknown>)[
             componentConfig.step
           ] as {
             createComponent: {
               forField: (config: {
-                field: string;
+                field?: string;
                 render: (field: unknown, props: unknown) => ReactNode;
               }) => (props?: unknown) => ReactNode;
             };
@@ -453,21 +671,44 @@ function createReactFactory<
             field: componentConfig.field,
             render: componentConfig.render,
           });
-          components.set(active, Component);
+          components.set(instance, Component);
         }
 
-        return createElement(Component as never, props as never);
+        return createElement(Component as never, componentProps as never);
       };
     },
   };
+
+  // The factory schema exposes the definition's step surface, but its reusable field
+  // components must bind to a real configured instance instead of the inert schema state.
+  for (const stepKey of stepKeys) {
+    const step = (factorySchema.stepSchema.value as Record<string, unknown>)[
+      stepKey
+    ] as {
+      createComponent: Function & {
+        forField: (config: {
+          field?: string;
+          render: (field: unknown, props: unknown) => ReactNode;
+        }) => (props?: unknown) => ReactNode;
+      };
+    };
+
+    Object.assign(step.createComponent, {
+      forField: (config: {
+        field?: string;
+        render: (field: unknown, props: unknown) => ReactNode;
+      }) => sharedFieldComponent.forField({ ...config, step: stepKey }),
+    });
+  }
+
   const sharedCreateComponent = Object.assign(
     function createFactoryComponent(componentConfig: unknown) {
       return factorySchema.createComponent(componentConfig as never);
     },
     sharedFieldComponent,
-  ) as unknown as CreateComponentFn<
-    DefineConfig<TSteps, TCasing>,
-    instantiateReactSteps<DefineConfig<TSteps, TCasing>>
+  ) as unknown as MultiStepFormReactFactoryCreateComponentFn<
+    TSteps,
+    TCasing
   >;
 
   return Object.assign(

--- a/packages/react/src/form-config.tsx
+++ b/packages/react/src/form-config.tsx
@@ -641,34 +641,22 @@ export namespace MultiStepFormSchemaConfig {
    * @param enabledFor The steps that the form _is_ enabled for.
    * @returns A boolean representing if the form should be available.
    */
-  // Note: the implementation is specific to `MultiStepFormStepSchema.createComponentForStep`
-  // because the `target` will always be an `Array` in `MultiStepFormStepSchema.createComponentForStep`.
-  // TODO add validation to keys
   export function isFormAvailable<
     value extends instantiateReactSteps,
     target extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
     enabledFor extends formEnabledFor<value>,
   >(target: target, enabledFor: enabledFor) {
-    if (Array.isArray(target)) {
-      const match = HelperFnChosenSteps.match({
-        meta: {
-          target,
-        },
-        default: () => false,
-        all: () => true,
-        tuple: ({ chosenSteps, meta }) => {
-          return chosenSteps.some((key) => meta.target.includes(key));
-        },
-        object: ({ chosenSteps, meta }) => {
-          return Object.keys(chosenSteps).some((key) =>
-            meta.target.includes(key as StepNumbers<value>),
-          );
-        },
-      });
-
-      return match<value, enabledFor>(enabledFor);
+    if (target === 'all' || enabledFor === 'all') {
+      return true;
     }
 
-    return false;
+    const targetSteps = Array.isArray(target) ? target : Object.keys(target);
+    const enabledSteps = Array.isArray(enabledFor)
+      ? enabledFor
+      : Object.keys(enabledFor);
+
+    // Availability follows the existing "any selected step" behavior for tuples and extends it
+    // consistently to object selectors and `all`.
+    return targetSteps.some((step) => enabledSteps.includes(step));
   }
 }

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -6,7 +6,7 @@ import {
   getDefaultValues,
   type getDeepFields,
   type HelperFn,
-  type HelperFnChosenSteps,
+  HelperFnChosenSteps,
   InvalidComponentError,
   InvalidFieldError,
   InvalidFormConfigError,
@@ -32,7 +32,6 @@ import {
   type StepSpecificCreateComponentFn,
 } from './steps';
 import {
-  createComponent,
   type CreateComponent,
   type CreatedMultiStepFormComponent,
   getValidatedCustomInputHooks,
@@ -78,6 +77,26 @@ export interface CreateComponentFn<
     value,
     targetStep,
     targetField,
+    customProps
+  >;
+
+  /** Creates a reusable component that selects a field from one step when rendered. */
+  forField<
+    targetStep extends StepNumbers<value>,
+    customProps extends object = {},
+  >(
+    config: StepSpecificComponent.selectableFieldConfig<
+      def,
+      value,
+      targetStep,
+      getDeepFields<value, targetStep>,
+      customProps
+    > & { step: targetStep },
+  ): StepSpecificComponent.selectableFieldComponent<
+    def,
+    value,
+    targetStep,
+    getDeepFields<value, targetStep>,
     customProps
   >;
 }
@@ -135,6 +154,7 @@ export class MultiStepFormStepSchema<
   value: value;
   // @ts-expect-error `value` is not assignable to the constraint of `value` but it works because of the `instantiateSteps` type
   readonly #internal: MultiStepFormStepSchemaInternal<def, value>;
+  readonly #form?: MultiStepFormSchemaConfig.FormConfig<def, value>;
   readonly createComponent: CreateComponentFn<def, value>;
 
   constructor(config: MultiStepFormStepSchema.config<def, value>) {
@@ -154,6 +174,7 @@ export class MultiStepFormStepSchema<
       getValue: () => this.value,
       setValue: (next) => this.handlePostUpdate(next as never),
     });
+    this.#form = form;
 
     this.sync();
 
@@ -677,7 +698,7 @@ export class MultiStepFormStepSchema<
         },
       );
 
-      const { field: targetField, render } = fieldConfig;
+      const { field: configuredField, render } = fieldConfig;
 
       InvalidComponentError.invariant(typeof render === 'function', {
         reason: 'The "render" property must be a function',
@@ -687,7 +708,9 @@ export class MultiStepFormStepSchema<
       });
 
       // Reuse the existing Field component so specialized components inherit its subscriptions,
-      // validation, deep-field support, and update/reset behavior.
+      // validation, deep-field support, and update/reset behavior. When the configuration omits
+      // a field, ownership moves to the returned component so one implementation can serve every
+      // compatible field in the step.
       return impl({
         render: (
           { Field }: StepSpecificComponent.input<def, value, targetStep, {}>,
@@ -698,19 +721,36 @@ export class MultiStepFormStepSchema<
             targetField,
             customProps
           >,
-        ) =>
-          createElement(
+        ) => {
+          const { field: selectedField, ...forwardedProps } = componentProps as
+            StepSpecificComponent.fieldComponentProps<
+              def,
+              value,
+              targetStep,
+              targetField,
+              customProps
+            > & { field?: targetField };
+          const targetField = configuredField ?? selectedField;
+
+          InvalidFieldError.invariant(targetField !== undefined, {
+            reason:
+              'The returned field component requires a "field" prop because its configuration did not provide one',
+            targetStep,
+          });
+
+          return createElement(
             Field as never,
             {
-              ...componentProps,
+              ...forwardedProps,
               name: targetField,
               children: (fieldProps: unknown) =>
                 render(
                   fieldProps as never,
-                  componentProps as unknown as customProps,
+                  forwardedProps as unknown as customProps,
                 ),
             } as never,
-          ),
+          );
+        },
       } as never);
     };
 
@@ -767,15 +807,169 @@ export class MultiStepFormStepSchema<
       return step.createComponent({ render } as never);
     }
 
-    return createComponent<value, chosenSteps, props>({
-      render: render as never,
-      input: ({ stepData }) => ({
+    const stepData = options.stepData as chosenSteps;
+    const getCtx = () => createCtx(this.value, stepData);
+    const useSelector = createUseSelector(getCtx as never, this.subscribe);
+    const Selector = selector.create(getCtx as never, this.subscribe);
+    const selectedSteps = this.getSelectedSteps(stepData);
+    const Field = this.createMultiStepField(selectedSteps);
+    const defaultFormId = selectedSteps.join('-');
+    const form = MultiStepFormSchemaConfig.instantiateFormConfig(
+      () => this.value,
+      this.subscribe,
+      Object.keys(this.value) as StepNumbers<value>[],
+    )(this.#form, defaultFormId) as
+      | undefined
+      | ({
+          alias: string;
+          enabledForSteps: HelperFnChosenSteps.main<
+            value,
+            StepNumbers<value>
+          >;
+        } & Record<string, unknown>);
+
+    return ((props: props) => {
+      const input: Record<string, unknown> = {
+        ctx: getCtx(),
         reset: this.#internal.createHelperFnInputReset(stepData),
         update: this.#internal.createHelperFnInputUpdate(stepData),
-      }),
-      options: options as HelperFn.BaseOptions<value, chosenSteps>,
-      value: this.value,
-    });
+        Field,
+        useSelector,
+        Selector,
+        defaultValues: this.createMultiStepDefaultValues(selectedSteps),
+      };
+
+      if (
+        form &&
+        MultiStepFormSchemaConfig.isFormAvailable(
+          stepData as never,
+          form.enabledForSteps as never,
+        )
+      ) {
+        input[form.alias] = form[form.alias];
+      }
+
+      return render(
+        input as StepSpecificComponent.instanceInput<
+          def,
+          value,
+          chosenSteps
+        >,
+        props,
+      );
+    }) as CreatedMultiStepFormComponent<props>;
+  }
+
+  private getSelectedSteps<
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  >(stepData: chosenSteps) {
+    if (stepData === 'all') {
+      return Object.keys(this.value) as StepNumbers<value>[];
+    }
+
+    if (Array.isArray(stepData)) {
+      return [...stepData] as StepNumbers<value>[];
+    }
+
+    return Object.keys(stepData) as StepNumbers<value>[];
+  }
+
+  private createMultiStepField(selectedSteps: StepNumbers<value>[]) {
+    type BridgeProps = {
+      children: (props: Record<string, unknown>) => ReactNode;
+      fieldName: string;
+      qualifiedName: string;
+    } & Record<string, unknown>;
+
+    const fields = new Map<string, CreatedMultiStepFormComponent<BridgeProps>>();
+
+    for (const step of selectedSteps) {
+      const stepValue = this.value[step] as {
+        createComponent: (config: {
+          render: (input: { Field: Function }, props: BridgeProps) => ReactNode;
+        }) => CreatedMultiStepFormComponent<BridgeProps>;
+      };
+      const StepField = stepValue.createComponent({
+        render({ Field }, props) {
+          const {
+            children,
+            fieldName,
+            qualifiedName,
+            ...fieldOptions
+          } = props;
+
+          return createElement(Field as never, {
+            ...fieldOptions,
+            name: fieldName,
+            children: (fieldProps: Record<string, unknown>) =>
+              children({ ...fieldProps, name: qualifiedName }),
+          } as never);
+        },
+      });
+
+      fields.set(step, StepField);
+    }
+
+    return (props: {
+      name: string;
+      children: (props: Record<string, unknown>) => ReactNode;
+    }) => {
+      const { name, children, ...fieldOptions } = props;
+
+      InvalidFieldError.invariant(typeof name === 'string', {
+        reason: 'The multi-step Field "name" prop must be a string',
+        field: name,
+      });
+
+      const separatorIndex = name.indexOf('.');
+      const step = name.slice(0, separatorIndex);
+      const fieldName = name.slice(separatorIndex + 1);
+
+      InvalidFieldError.invariant(
+        separatorIndex > 0 && fields.has(step),
+        {
+          reason: `The field name "${name}" must start with one of the selected steps`,
+          field: name,
+          validSteps: selectedSteps,
+        },
+      );
+
+      const StepField = fields.get(step)!;
+
+      return createElement(StepField as never, {
+        ...fieldOptions,
+        children,
+        fieldName,
+        qualifiedName: name,
+      } as never);
+    };
+  }
+
+  private createMultiStepDefaultValues(
+    selectedSteps: StepNumbers<value>[],
+  ) {
+    const grouped = Object.fromEntries(
+      selectedSteps.map((step) => [step, this.createDefaultValues(step)]),
+    );
+    const fields = new Map<string, Array<[string, unknown]>>();
+
+    for (const [step, defaultValues] of Object.entries(grouped)) {
+      for (const [field, defaultValue] of Object.entries(defaultValues)) {
+        const matches = fields.get(field) ?? [];
+
+        matches.push([step, defaultValue]);
+        fields.set(field, matches);
+      }
+    }
+
+    const flat = Object.fromEntries(
+      [...fields].map(([field, matches]) => [
+        field,
+        matches.length === 1 ? matches[0][1] : Object.fromEntries(matches),
+      ]),
+    );
+
+    return { grouped, flat };
   }
 
   createDefaultValues<targetStep extends StepNumbers<value>>(

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -25,62 +25,205 @@ import {
 } from './utils';
 
 export namespace StepSpecificComponent {
-  type instantiateFormComponentForAllSteps<
-    def extends StepSchema.Config,
-    value = MultiStepFormSchemaConfig.instantiateFormConfig<def>,
-  > =
-    MultiStepFormSchemaConfig.EnabledForSteps.get<value> extends MultiStepFormSchemaConfig.defaultEnabledFor
-      ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
-      : {};
-  type instantiateFormComponentForTuple<
-    def extends StepSchema.Config,
-    steps extends instantiateReactSteps,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
-  > =
-    MultiStepFormSchemaConfig.EnabledForSteps.get<def> extends HelperFnChosenSteps.tupleNotation<
-      StepNumbers<steps>
-    >
-      ? chosenSteps[number] extends StepNumbers<steps>
-        ? chosenSteps[number] extends MultiStepFormSchemaConfig.EnabledForSteps.get<def>[number]
-          ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
-          : {}
-        : {}
-      : {};
-
-  type instantiateFormComponentForObject<
-    def extends StepSchema.Config,
-    steps extends instantiateReactSteps,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
-  > =
-    MultiStepFormSchemaConfig.EnabledForSteps.get<def> extends HelperFnChosenSteps.objectNotation<
-      StepNumbers<steps>
-    >
-      ? chosenSteps[number] extends StepNumbers<steps>
-        ? chosenSteps[number] extends keyof MultiStepFormSchemaConfig.EnabledForSteps.get<def>
-          ? MultiStepFormSchemaConfig.instantiateFormConfig<def>
-          : {}
-        : {}
-      : {};
-  type instantiateFormComponent<
+  type enabledFormSteps<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps<def>,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
-  > = {
-    all: instantiateFormComponentForAllSteps<def>;
-    tuple: instantiateFormComponentForTuple<def, steps, chosenSteps>;
-    object: instantiateFormComponentForObject<def, steps, chosenSteps>;
-  };
-  // A form component can only be selected unambiguously when one concrete step is targeted.
-  // Instance-level `createComponent` delegates that case to the same step-specific factory.
+  > = MultiStepFormSchemaConfig.instantiateFormConfig<def> extends {
+    enabledForSteps: infer enabled;
+  }
+    ? enabled extends HelperFnChosenSteps.main<steps, StepNumbers<steps>>
+      ? HelperFnChosenSteps.resolve<steps, enabled>
+      : never
+    : never;
+
   export type formComponent<
     def extends StepSchema.Config,
     steps extends instantiateReactSteps<def>,
-    chosenSteps extends HelperFnChosenSteps.tupleNotation<StepNumbers<steps>>,
-  > = instantiateFormComponent<
-    def,
-    steps,
-    chosenSteps
-  >[MultiStepFormSchemaConfig.EnabledForSteps.resolveType<def, steps>];
+    chosenSteps extends HelperFnChosenSteps.main<steps, StepNumbers<steps>>,
+  > = Extract<
+    HelperFnChosenSteps.resolve<steps, chosenSteps>,
+    enabledFormSteps<def, steps>
+  > extends never
+    ? {}
+    : MultiStepFormSchemaConfig.instantiateFormConfig<def>;
+
+  type selectedDefaultValues<
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  > = {
+    [step in HelperFnChosenSteps.resolve<
+      value,
+      chosenSteps
+    >]: Expand<getDefaultValues<value, step>>;
+  };
+
+  type keysOfUnion<value> = value extends value ? keyof value : never;
+  type valueForKey<value, key extends PropertyKey> = value extends value
+    ? key extends keyof value
+      ? value[key]
+      : never
+    : never;
+  type stepsContainingField<
+    grouped,
+    field extends PropertyKey,
+  > = {
+    [step in keyof grouped]: field extends keyof grouped[step] ? step : never;
+  }[keyof grouped];
+  type isUnion<value, original = value> = value extends original
+    ? [original] extends [value]
+      ? false
+      : true
+    : never;
+  type groupedFieldValues<
+    grouped,
+    field extends PropertyKey,
+  > = Expand<{
+    [step in stepsContainingField<grouped, field>]: field extends keyof grouped[step]
+      ? grouped[step][field]
+      : never;
+  }>;
+  type flatFieldValue<grouped, field extends PropertyKey> = isUnion<
+    stepsContainingField<grouped, field>
+  > extends true
+    ? groupedFieldValues<grouped, field>
+    : valueForKey<grouped[keyof grouped], field>;
+
+  export type multiStepDefaultValues<
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+    grouped extends selectedDefaultValues<value, chosenSteps> = selectedDefaultValues<
+      value,
+      chosenSteps
+    >,
+  > = {
+    /** Default field values grouped under their selected step keys. */
+    grouped: Expand<grouped>;
+    /**
+     * Default field values from every selected step merged into one object.
+     * A field name declared by multiple selected steps is grouped under those step keys so no
+     * value is overwritten.
+     */
+    flat: Expand<{
+      [field in keysOfUnion<grouped[keyof grouped]>]: flatFieldValue<
+        grouped,
+        field
+      >;
+    }>;
+  };
+
+  export type multiStepFieldName<
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  > = {
+    [step in HelperFnChosenSteps.resolve<
+      value,
+      chosenSteps
+    >]: `${step}.${getDeepFields<value, step>}`;
+  }[HelperFnChosenSteps.resolve<value, chosenSteps>];
+
+  type stepFromFieldName<name extends string> = name extends `${infer step}.${string}`
+    ? step
+    : never;
+  type fieldFromFieldName<name extends string> = name extends `${string}.${infer field}`
+    ? field
+    : never;
+  type multiStepFieldChildrenProps<
+    value extends instantiateReactSteps,
+    name extends string,
+    selected,
+    step extends StepNumbers<value> = Extract<
+      stepFromFieldName<name>,
+      StepNumbers<value>
+    >,
+    targetField extends getDeepFields<value, step> = Extract<
+      fieldFromFieldName<name>,
+      getDeepFields<value, step>
+    >,
+  > = Expand<
+    Omit<
+      [selected] extends [never]
+        ? field.childrenProps<value, targetField, step>
+        : field.childrenPropsWithSelected<
+            value,
+            step,
+            targetField,
+            selected
+          >,
+      'name'
+    > & { name: name }
+  >;
+  type selectedFieldStep<
+    value extends instantiateReactSteps,
+    step extends StepNumbers<value>,
+  > = Expand<{ [key in step]: value[key] }>;
+  type selectedFieldStepKey<
+    value extends instantiateReactSteps,
+    step extends StepNumbers<value>,
+  > = StepNumbers<selectedFieldStep<value, step>>;
+  type multiStepFieldProps<
+    value extends instantiateReactSteps,
+    name extends string,
+    selected,
+    step extends StepNumbers<value> = Extract<
+      stepFromFieldName<name>,
+      StepNumbers<value>
+    >,
+    targetField extends getDeepFields<value, step> = Extract<
+      fieldFromFieldName<name>,
+      getDeepFields<value, step>
+    >,
+  > = Expand<
+    Omit<
+      field.boundProps<
+        selectedFieldStep<value, step>,
+        selectedFieldStepKey<value, step>,
+        Extract<
+          targetField,
+          getDeepFields<
+            selectedFieldStep<value, step>,
+            selectedFieldStepKey<value, step>
+          >
+        >,
+        selected
+      >,
+      'name' | 'children'
+    > & {
+      name: name;
+      children: (
+        props: multiStepFieldChildrenProps<value, name, selected>,
+      ) => ReactNode;
+    }
+  >;
+  export type multiStepFieldComponent<
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  > = <
+    name extends multiStepFieldName<value, chosenSteps>,
+    selected = never,
+  >(
+    props: multiStepFieldProps<value, name, selected>,
+  ) => ReactNode;
+
+  export type multiStepInput<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  > = Expand<
+    HelperFnInput.BaseInput<value, chosenSteps, never, {}> &
+      formComponent<def, value, chosenSteps> & {
+        /**
+         * Renders a field from any selected step. Names include the owning step, such as
+         * `step1.firstName`, so fields with the same name remain unambiguous.
+         */
+        Field: multiStepFieldComponent<value, chosenSteps>;
+        /** Reactively selects a value from the selected steps' context. */
+        useSelector: UseSelector<HelperFn.buildCtx<value, chosenSteps>>;
+        /** Reactively renders a selected value without rerendering the parent component. */
+        Selector: selector.component<HelperFn.buildCtx<value, chosenSteps>>;
+        /** Default values for the selected steps in grouped and flattened forms. */
+        defaultValues: multiStepDefaultValues<value, chosenSteps>;
+      }
+  >;
   export type updateWrappers<
     value extends instantiateReactSteps,
     targetStep extends StepNumbers<value>,
@@ -259,10 +402,12 @@ export namespace StepSpecificComponent {
     value extends instantiateReactSteps<def>,
     targetStep extends StepNumbers<value>,
     targetField extends getDeepFields<value, targetStep>,
-  > = field.childrenProps<value, targetField, targetStep> & {
-    /** Present when the returned component receives a `selectorFn`. */
-    selected?: { value: unknown };
-  };
+  > = targetField extends getDeepFields<value, targetStep>
+    ? field.childrenProps<value, targetField, targetStep> & {
+        /** Present when the returned component receives a `selectorFn`. */
+        selected?: { value: unknown };
+      }
+    : never;
 
   export type fieldComponentProps<
     def extends StepSchema.Config,
@@ -295,6 +440,41 @@ export namespace StepSpecificComponent {
     >,
   ) => ReactNode;
 
+  export type selectableFieldComponentProps<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+  > = Expand<
+    fieldComponentProps<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps
+    > & {
+      /** Selects which field in the component's step is rendered. */
+      field: targetField;
+    }
+  >;
+
+  export type selectableFieldComponent<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+  > = (
+    props: selectableFieldComponentProps<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps
+    >,
+  ) => ReactNode;
+
   export type fieldConfig<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
@@ -303,6 +483,19 @@ export namespace StepSpecificComponent {
     customProps extends object,
   > = {
     field: targetField;
+    render: CreateComponent<
+      fieldInput<def, value, targetStep, targetField>,
+      customProps
+    >;
+  };
+
+  export type selectableFieldConfig<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+  > = {
     render: CreateComponent<
       fieldInput<def, value, targetStep, targetField>,
       customProps
@@ -318,7 +511,7 @@ export namespace StepSpecificComponent {
         input<def, value, targetStep, {}> &
           formComponent<def, value, [targetStep]>
       >
-    : HelperFnInput.BaseInput<value, chosenSteps, never, {}>;
+    : multiStepInput<def, value, chosenSteps>;
 }
 
 type IsLegacyFormAvailable<
@@ -386,6 +579,23 @@ export interface StepSpecificCreateComponentFn<
     value,
     targetStep,
     targetField,
+    customProps
+  >;
+
+  /** Creates a reusable component that selects one of this step's fields when rendered. */
+  forField<customProps extends object = {}>(
+    config: StepSpecificComponent.selectableFieldConfig<
+      def,
+      value,
+      targetStep,
+      getDeepFields<value, targetStep>,
+      customProps
+    >,
+  ): StepSpecificComponent.selectableFieldComponent<
+    def,
+    value,
+    targetStep,
+    getDeepFields<value, targetStep>,
     customProps
   >;
 }

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -142,38 +142,160 @@ describe('creating components via "createComponent" fn', () => {
         steps: {
           step1: {
             title: 'Contact',
-            fields: { firstName: { defaultValue: 'Taylor' } },
+            fields: {
+              firstName: { defaultValue: 'Taylor' },
+              email: { defaultValue: 'client@example.com' },
+            },
           },
           step2: {
             title: 'Details',
-            fields: { age: { defaultValue: 30 } },
+            fields: {
+              age: { defaultValue: 30 },
+              email: { defaultValue: 'admin@example.com' },
+            },
           },
         },
       }).configure()();
 
       const AllSteps = schema.createComponent({
         stepData: 'all',
-        render({ ctx }) {
+        render({ ctx, defaultValues, Selector, useSelector }) {
+          const selectedAge = useSelector(
+            (steps) => steps.step2.fields.age.defaultValue,
+          );
+
           expectTypeOf(
             ctx.step1.fields.firstName.defaultValue,
           ).toEqualTypeOf<string>();
           expectTypeOf(
             ctx.step2.fields.age.defaultValue,
           ).toEqualTypeOf<number>();
+          expectTypeOf(defaultValues.grouped.step1.firstName).toEqualTypeOf<
+            string
+          >();
+          expectTypeOf(defaultValues.grouped.step2.age).toEqualTypeOf<number>();
+          expectTypeOf(defaultValues.flat.firstName).toEqualTypeOf<string>();
+          expectTypeOf(defaultValues.flat.age).toEqualTypeOf<number>();
+          expectTypeOf(defaultValues.flat.email.step1).toEqualTypeOf<string>();
+          expectTypeOf(defaultValues.flat.email.step2).toEqualTypeOf<string>();
+          expectTypeOf(Selector).toBeFunction();
+          expectTypeOf(selectedAge).toEqualTypeOf<number>();
 
           return (
-            <span data-testid='all-steps'>
-              {ctx.step1.fields.firstName.defaultValue}:{
-                ctx.step2.fields.age.defaultValue
-              }
-            </span>
+            <>
+              <span data-testid='all-steps'>
+                {defaultValues.flat.firstName}:{defaultValues.grouped.step2.age}
+                :{selectedAge}
+              </span>
+              <Selector
+                selector={(steps) =>
+                  steps.step1.fields.firstName.defaultValue
+                }
+              >
+                {(firstName) => (
+                  <span data-testid='all-steps-selector'>{firstName}</span>
+                )}
+              </Selector>
+            </>
           );
         },
       });
 
       const screen = await renderInJsdom(<AllSteps />);
 
-      expect(screen.getByTestId('all-steps').textContent).toBe('Taylor:30');
+      expect(screen.getByTestId('all-steps').textContent).toBe('Taylor:30:30');
+      expect(screen.getByTestId('all-steps-selector').textContent).toBe(
+        'Taylor',
+      );
+    });
+
+    it('provides grouped and flat default values for multiple selected steps', async () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Contact',
+            fields: {
+              firstName: { defaultValue: 'Taylor' },
+              email: { defaultValue: 'client@example.com' },
+            },
+          },
+          step2: {
+            title: 'Details',
+            fields: {
+              age: { defaultValue: 30 },
+              email: { defaultValue: 'admin@example.com' },
+            },
+          },
+          step3: {
+            title: 'Unselected',
+            fields: { accepted: { defaultValue: false } },
+          },
+        },
+      }).configure()();
+
+      const SelectedSteps = schema.createComponent({
+        stepData: ['step1', 'step2'],
+        render({ defaultValues, Field }) {
+          expectTypeOf<keyof typeof defaultValues.grouped>().toEqualTypeOf<
+            'step1' | 'step2'
+          >();
+          expectTypeOf(defaultValues.flat.firstName).toEqualTypeOf<string>();
+          expectTypeOf(defaultValues.flat.age).toEqualTypeOf<number>();
+          expectTypeOf(defaultValues.flat.email.step1).toEqualTypeOf<string>();
+          expectTypeOf(defaultValues.flat.email.step2).toEqualTypeOf<string>();
+
+          if (false) {
+            // @ts-expect-error Unselected step defaults are not included.
+            defaultValues.grouped.step3;
+            // @ts-expect-error Unselected field defaults are not included.
+            defaultValues.flat.accepted;
+            // @ts-expect-error Field paths must belong to a selected step.
+            <Field name='step3.accepted'>{() => null}</Field>;
+            // @ts-expect-error Field paths must contain the owning step.
+            <Field name='firstName'>{() => null}</Field>;
+          }
+
+          return (
+            <>
+              <span data-testid='selected-default-values'>
+                {defaultValues.grouped.step1.firstName}:
+                {defaultValues.flat.age}:{defaultValues.flat.email.step1}:
+                {defaultValues.flat.email.step2}
+              </span>
+              <Field name='step1.firstName'>
+                {(field) => {
+                  expectTypeOf(field.name).toEqualTypeOf<'step1.firstName'>();
+                  expectTypeOf(field.defaultValue).toEqualTypeOf<string>();
+
+                  return (
+                    <button
+                      data-testid='multi-step-field'
+                      onClick={() => field.onInputChange('Jordan')}
+                    >
+                      {field.name}:{field.defaultValue}
+                    </button>
+                  );
+                }}
+              </Field>
+            </>
+          );
+        },
+      });
+
+      const screen = await renderInJsdom(<SelectedSteps />);
+
+      expect(screen.getByTestId('selected-default-values').textContent).toBe(
+        'Taylor:30:client@example.com:admin@example.com',
+      );
+      const field = screen.getByTestId('multi-step-field');
+
+      expect(field.textContent).toBe('step1.firstName:Taylor');
+
+      await act(async () => {
+        field.click();
+      });
+
+      expect(field.textContent).toBe('step1.firstName:Jordan');
     });
 
     it('preserves step helpers for a partial object step selector', async () => {
@@ -778,8 +900,8 @@ describe('creating components via "createComponent" fn', () => {
 });
 
 describe('creating reusable components via "createComponent.forField"', () => {
-  it('creates a field component without custom props', async () => {
-    const schema = defineMultiStepForm({
+  it('creates a selectable field component for explicit instances without custom props', async () => {
+    const createForm = defineMultiStepForm({
       steps: {
         step1: {
           title: 'Contact',
@@ -788,51 +910,77 @@ describe('creating reusable components via "createComponent.forField"', () => {
               defaultValue: 'Taylor',
               label: 'First name',
             },
+            lastName: {
+              defaultValue: 'Client',
+              label: 'Last name',
+            },
           },
         },
       },
-    }).configure()();
+      instances: ['client', 'admin'],
+    }).configure();
+    const client = createForm({ instance: 'client' }).withOverrides({
+      step1: async () => ({
+        firstName: 'Client override',
+        lastName: 'Wrong client field',
+      }),
+    });
+    const admin = createForm({ instance: 'admin' }).withOverrides({
+      step1: async () => ({
+        firstName: 'Wrong admin field',
+        lastName: 'Admin override',
+      }),
+    });
 
-    const FirstName = schema.stepSchema.value.step1.createComponent.forField({
-      field: 'firstName',
+    const Name = createForm.stepSchema.value.step1.createComponent.forField({
       render(field) {
-        expectTypeOf(field.name).toEqualTypeOf<'firstName'>();
+        expectTypeOf(field.name).toEqualTypeOf<'firstName' | 'lastName'>();
         expectTypeOf(field.defaultValue).toEqualTypeOf<string>();
 
-        return (
-          <button
-            data-testid='first-name'
-            onClick={() => field.onInputChange('Jordan')}
-          >
-            {field.defaultValue}
-          </button>
-        );
+        return <p>{field.defaultValue}</p>;
       },
     });
 
-    const screen = await renderInJsdom(<FirstName suspend={false} />);
-    const button = screen.getByTestId('first-name');
+    if (false) {
+      // @ts-expect-error Factory field components must choose an instance explicitly.
+      <Name field='firstName' />;
+      // @ts-expect-error Only fields declared by step1 can be selected.
+      <Name instance={client} field='email' />;
+    }
 
-    expect(button.textContent).toContain('Taylor');
+    const screen = await renderInJsdom(
+      <>
+        <Name
+          instance={client}
+          field='firstName'
+          suspend
+          fallback={<p>Loading client</p>}
+        />
+        <Name
+          instance={admin}
+          field='lastName'
+          suspend
+          fallback={<p>Loading admin</p>}
+        />
+      </>,
+    );
 
-    await act(async () => {
-      button.click();
-    });
-
-    expect(button.textContent).toContain('Jordan');
+    expect(screen.getByText('Client override')).toBeDefined();
+    expect(screen.getByText('Admin override')).toBeDefined();
   });
 
-  it('creates a field component with custom props', async () => {
-    const schema = defineMultiStepForm({
+  it('creates a bound field component for an explicit instance with custom props', async () => {
+    const createForm = defineMultiStepForm({
       steps: {
         step2: {
           title: 'Details',
           fields: { age: { defaultValue: 30 } },
         },
       },
-    }).configure()();
+    }).configure();
+    const instance = createForm();
 
-    const Age = schema.createComponent.forField({
+    const Age = createForm.createComponent.forField({
       step: 'step2',
       field: 'age',
       render(field, props: { suffix: string }) {
@@ -847,7 +995,9 @@ describe('creating reusable components via "createComponent.forField"', () => {
       },
     });
 
-    const screen = await renderInJsdom(<Age suffix='years' />);
+    const screen = await renderInJsdom(
+      <Age instance={instance} suffix='years' />,
+    );
 
     expect(screen.getByText('Age: 30 years')).toBeDefined();
   });

--- a/packages/react/test/step-schema/form-availability.test.tsx
+++ b/packages/react/test/step-schema/form-availability.test.tsx
@@ -69,7 +69,7 @@ describe('createComponent Form availability', () => {
     });
     let receivedForm: unknown;
     const Component = schema.createComponent({
-      stepData: ['step1'],
+      stepData: 'all',
       render({ Form }) {
         expectTypeOf(Form).toBeFunction();
         receivedForm = Form;
@@ -92,7 +92,7 @@ describe('createComponent Form availability', () => {
     });
     let receivedForm: unknown;
     const Component = schema.createComponent({
-      stepData: ['step1'],
+      stepData: 'all',
       render({ CustomForm }) {
         expectTypeOf(CustomForm).toBeFunction();
         receivedForm = CustomForm;


### PR DESCRIPTION
## Summary

- require explicit instances for shared field components and keep per-instance overrides isolated
- allow reusable selectable field components and qualified multi-step `Field` paths
- restore multi-step render utilities and grouped/flat defaults without collisions

## Why

Shared factory components previously depended on mutable active-instance state, and multi-step components lost React render utilities. This could select the wrong instance and made reusable TanStack Form integrations incomplete.

## Validation

- `pnpm test:react`
- `pnpm typecheck:packages`
- `pnpm build:packages`
- `pnpm build:react`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 90eaceb32502c11c78e44ce2c4c2dd2791715c3a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->