### PR TITLE
fix(react): preserve field types in declarations

### DIFF
--- a/.changeset/honest-fields-type.md
+++ b/.changeset/honest-fields-type.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Preserve the internal Field type namespace in published declarations so consumer render callbacks retain strongly typed field props.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,4 +3,7 @@ export * from './step-schema';
 export * from './steps';
 export * from './create-context';
 export * from './define';
+// Public component signatures reference these types, so the declaration build must preserve
+// the namespace even though consumers do not need the Field runtime implementation directly.
+export type { field } from './field';
 export { useMultiStepFormData } from './hooks/use-multi-step-form-data';

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -14,7 +14,7 @@ import type {
 } from '@jfdevelops/multi-step-form-core';
 import { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
 import type { ReactNode } from 'react';
-import { field } from './field';
+import type * as FieldTypes from './field';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { UseSelector } from './hooks/use-selector';
 import { selector } from './selector';
@@ -142,8 +142,8 @@ export namespace StepSpecificComponent {
   > = Expand<
     Omit<
       [selected] extends [never]
-        ? field.childrenProps<value, targetField, step>
-        : field.childrenPropsWithSelected<
+        ? FieldTypes.field.childrenProps<value, targetField, step>
+        : FieldTypes.field.childrenPropsWithSelected<
             value,
             step,
             targetField,
@@ -174,7 +174,7 @@ export namespace StepSpecificComponent {
     >,
   > = Expand<
     Omit<
-      field.boundProps<
+      FieldTypes.field.boundProps<
         selectedFieldStep<value, step>,
         selectedFieldStepKey<value, step>,
         Extract<
@@ -293,7 +293,9 @@ export namespace StepSpecificComponent {
     additionalCtx extends Record<string, unknown>,
   > = HelperFnInput.BaseInput<value, [targetStep], never, additionalCtx> &
     updateWrappers<value, targetStep> & {
-      Field: field.component<buildCurrentStep<def, value, targetStep>>;
+      Field: FieldTypes.field.component<
+        buildCurrentStep<def, value, targetStep>
+      >;
       /**
        * A hook for reactively selecting a value from the form context.
        * The selector function receives the contextual data for the currently rendered step, and returns any derived value.
@@ -403,7 +405,7 @@ export namespace StepSpecificComponent {
     targetStep extends StepNumbers<value>,
     targetField extends getDeepFields<value, targetStep>,
   > = targetField extends getDeepFields<value, targetStep>
-    ? field.childrenProps<value, targetField, targetStep> & {
+    ? FieldTypes.field.childrenProps<value, targetField, targetStep> & {
         /** Present when the returned component receives a `selectorFn`. */
         selected?: { value: unknown };
       }
@@ -418,7 +420,7 @@ export namespace StepSpecificComponent {
   > = Expand<
     // `forField` owns these two props so callers cannot replace its field binding or renderer.
     Omit<
-      field.boundProps<value, targetStep, targetField, unknown>,
+      FieldTypes.field.boundProps<value, targetStep, targetField, unknown>,
       'name' | 'children'
     > &
       Omit<customProps, 'name' | 'children'>


### PR DESCRIPTION
## Summary

- preserve the internal `field` type namespace in published declarations
- make generated step declarations explicitly import their Field type dependency
- restore contextual typing for consumer `Field` render callbacks
- add a patch changeset for the React package

## Root cause

The generated `steps.d.ts` referenced `field.component` and `field.childrenProps` without importing or emitting the internal `field` namespace. Consumers using the built package therefore received `any` for Field callback arguments, causing the example app's strict TypeScript build to fail.

## Impact

External consumers keep strongly typed `defaultValue`, `label`, `onInputChange`, and the rest of the Field render context without adding casts or manual annotations.

## Validation

- `pnpm build`
- full pre-commit package tests, typechecks, and package builds passed before the fix was moved to this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-declaration-only fix with no runtime behavior changes. Risk is limited to published consumer typing.
> 
> **Overview**
> Fixes published TypeScript declarations so consumer `Field` render callbacks keep strongly typed props instead of falling back to `any`.
> 
> Re-exports the internal `field` type namespace from the package entry, and updates `steps.ts` to import it as `FieldTypes` so generated `.d.ts` files retain an explicit type dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa44c0bc1df6d80be1cf24bddec4390d1ea91ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->