### PR TITLE
fix(react): normalize reusable field component types

### DIFF
--- a/.changeset/calm-fields-reuse.md
+++ b/.changeset/calm-fields-reuse.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': minor
+---
+
+Keep unique multi-step default values flat while grouping only duplicate field names by step, and add `asReusable(field)` to selectable `createComponent.forField` components.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Agent Rules
+
+## Git branches
+
+- Never create or switch to a new branch unless the user explicitly instructs you to create one.
+- A request to commit, push, or open a pull request does not grant permission to create a branch.
+- When the user explicitly requests a new branch, its name must start with exactly one of these prefixes followed by `/`: `feat/`, `fix/`, `docs/`, `test/`, `chore/`, `ci/`, `refactor/`, `hotfix/`.
+- Never use any other branch prefix, including `agent/`.
+- Before creating an authorized branch, confirm the proposed branch name satisfies the allowed-prefix rule.
+- Never commit without permission
+- New PR will NEVER be a draft
+- Commits must always follow this format: type(scope): subject
+  - I NEVER want to see any description

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsdown",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "watch": "tsdown --watch",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -9,8 +9,6 @@ import {
   type DefaultCasing,
   type DefineConfig,
   type DefineMultiStepFormOptions,
-  type Expand,
-  type getDeepFields,
   type HelperFn,
   type HelperFnChosenSteps,
   InvalidComponentError,
@@ -24,6 +22,7 @@ import {
   type AnyMultiStepFormSchema,
   MultiStepFormSchema,
 } from './schema';
+import { ForField, withReusableField } from './for-field';
 import {
   type instantiateReactSteps,
   type StepSpecificComponent,
@@ -236,37 +235,6 @@ export interface MultiStepFormReactFactoryStepFunctions<
   createHelperFn: StepSpecificHelperFn<DefineReactValue<TSteps>, key>;
 }
 
-type FactoryFieldComponentProps<
-  TSteps extends StepConfig,
-  TCasing extends CasingType,
-  targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
-  targetField extends getDeepFields<
-    DefineReactValue<TSteps, TCasing>,
-    targetStep
-  >,
-  customProps extends object,
-  selectable extends boolean,
-> = Expand<
-  (selectable extends true
-    ? StepSpecificComponent.selectableFieldComponentProps<
-        DefineConfig<TSteps, TCasing>,
-        DefineReactValue<TSteps, TCasing>,
-        targetStep,
-        targetField,
-        customProps
-      >
-    : StepSpecificComponent.fieldComponentProps<
-        DefineConfig<TSteps, TCasing>,
-        DefineReactValue<TSteps, TCasing>,
-        targetStep,
-        targetField,
-        customProps
-      >) & {
-    /** The configured form instance whose state and overrides this component reads. */
-    instance: AnyMultiStepFormSchema;
-  }
->;
-
 interface MultiStepFormReactFactoryCreateComponentFn<
   TSteps extends StepConfig,
   TCasing extends CasingType,
@@ -293,92 +261,12 @@ interface MultiStepFormReactFactoryCreateComponentFn<
     },
   ): CreatedMultiStepFormComponent<props>;
 
-  /**
-   * Creates a reusable field component from the definition.
-   *
-   * Pass the schema to render through the returned component's `instance` prop so one
-   * definition can be shared by independently configured form instances.
-   */
-  forField<
-    targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
-    targetField extends getDeepFields<
-      DefineReactValue<TSteps, TCasing>,
-      targetStep
-    >,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.fieldConfig<
-      DefineConfig<TSteps, TCasing>,
-      DefineReactValue<TSteps, TCasing>,
-      targetStep,
-      targetField,
-      customProps
-    > & { step: targetStep },
-  ): (
-    props: FactoryFieldComponentProps<
-      TSteps,
-      TCasing,
-      targetStep,
-      targetField,
-      customProps,
-      false
-    >,
-  ) => ReactNode;
+  forField: ForField.createComponentFn<
+    DefineConfig<TSteps, TCasing>,
+    DefineReactValue<TSteps, TCasing>,
+    { instance: AnyMultiStepFormSchema }
+  >;
 
-  /**
-   * Creates a reusable component whose field is selected when the component is rendered.
-   * The selected instance supplies current values, overrides, and subscriptions.
-   */
-  forField<
-    targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
-    targetField extends getDeepFields<
-      DefineReactValue<TSteps, TCasing>,
-      targetStep
-    >,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.selectableFieldConfig<
-      DefineConfig<TSteps, TCasing>,
-      DefineReactValue<TSteps, TCasing>,
-      targetStep,
-      targetField,
-      customProps
-    > & { fields: readonly targetField[]; step: targetStep },
-  ): (
-    props: FactoryFieldComponentProps<
-      TSteps,
-      TCasing,
-      targetStep,
-      targetField,
-      customProps,
-      true
-    >,
-  ) => ReactNode;
-
-  forField<
-    targetStep extends StepNumbers<DefineReactValue<TSteps, TCasing>>,
-    customProps extends object = {},
-  >(
-    config: Omit<
-      StepSpecificComponent.selectableFieldConfig<
-        DefineConfig<TSteps, TCasing>,
-        DefineReactValue<TSteps, TCasing>,
-        targetStep,
-        getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
-        customProps
-      >,
-      'fields'
-    > & { fields?: undefined; step: targetStep },
-  ): (
-    props: FactoryFieldComponentProps<
-      TSteps,
-      TCasing,
-      targetStep,
-      getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
-      customProps,
-      true
-    >,
-  ) => ReactNode;
 }
 
 interface MultiStepFormReactFactoryStepCreateComponentFn<
@@ -396,85 +284,13 @@ interface MultiStepFormReactFactoryStepCreateComponentFn<
     >,
   ): CreatedMultiStepFormComponent<props>;
 
-  /**
-   * Creates a reusable component bound to one field in this factory step.
-   * The returned component requires the schema instance whose field data it should read.
-   */
-  forField<
-    targetField extends getDeepFields<
-      DefineReactValue<TSteps, TCasing>,
-      targetStep
-    >,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.fieldConfig<
-      DefineConfig<TSteps, TCasing>,
-      DefineReactValue<TSteps, TCasing>,
-      targetStep,
-      targetField,
-      customProps
-    >,
-  ): (
-    props: FactoryFieldComponentProps<
-      TSteps,
-      TCasing,
-      targetStep,
-      targetField,
-      customProps,
-      false
-    >,
-  ) => ReactNode;
+  forField: ForField.stepCreateComponentFn<
+    DefineConfig<TSteps, TCasing>,
+    DefineReactValue<TSteps, TCasing>,
+    targetStep,
+    { instance: AnyMultiStepFormSchema }
+  >;
 
-  /**
-   * Creates a reusable component that selects one field in this factory step at render time.
-   * The selected instance supplies current values, overrides, and subscriptions.
-   */
-  forField<
-    targetField extends getDeepFields<
-      DefineReactValue<TSteps, TCasing>,
-      targetStep
-    >,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.selectableFieldConfig<
-      DefineConfig<TSteps, TCasing>,
-      DefineReactValue<TSteps, TCasing>,
-      targetStep,
-      targetField,
-      customProps
-    > & { fields: readonly targetField[] },
-  ): (
-    props: FactoryFieldComponentProps<
-      TSteps,
-      TCasing,
-      targetStep,
-      targetField,
-      customProps,
-      true
-    >,
-  ) => ReactNode;
-
-  forField<customProps extends object = {}>(
-    config: Omit<
-      StepSpecificComponent.selectableFieldConfig<
-        DefineConfig<TSteps, TCasing>,
-        DefineReactValue<TSteps, TCasing>,
-        targetStep,
-        getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
-        customProps
-      >,
-      'fields'
-    > & { fields?: undefined },
-  ): (
-    props: FactoryFieldComponentProps<
-      TSteps,
-      TCasing,
-      targetStep,
-      getDeepFields<DefineReactValue<TSteps, TCasing>, targetStep>,
-      customProps,
-      true
-    >,
-  ) => ReactNode;
 }
 
 type MultiStepFormReactFactoryStepSchema<
@@ -715,7 +531,7 @@ function createReactFactory<
       // component identity and subscriptions without relying on mutable global selection.
       const components = new WeakMap<object, (props?: unknown) => ReactNode>();
 
-      return (props?: unknown) => {
+      function SharedField(props?: unknown) {
         InvalidComponentError.invariant(
           typeof props === 'object' &&
             props !== null &&
@@ -756,7 +572,9 @@ function createReactFactory<
         }
 
         return createElement(Component as never, componentProps as never);
-      };
+      }
+
+      return withReusableField(SharedField as never);
     },
   };
 

--- a/packages/react/src/for-field.ts
+++ b/packages/react/src/for-field.ts
@@ -1,0 +1,237 @@
+import type {
+  Expand,
+  getDeepFields,
+  StepNumbers,
+} from '@jfdevelops/multi-step-form-core';
+import type { StepSchema } from '@jfdevelops/multi-step-form-core/_internals';
+import { createElement, type ReactNode } from 'react';
+import type {
+  instantiateReactSteps,
+  StepSpecificComponent,
+} from './steps';
+
+export namespace ForField {
+  type componentProps<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+    additionalProps extends object,
+  > = Expand<
+    StepSpecificComponent.fieldComponentProps<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps
+    > &
+      additionalProps
+  >;
+
+  export type boundComponent<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+    additionalProps extends object = {},
+  > = (
+    props: componentProps<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps,
+      additionalProps
+    >,
+  ) => ReactNode;
+
+  export type selectableComponent<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    targetField extends getDeepFields<value, targetStep>,
+    customProps extends object,
+    additionalProps extends object = {},
+  > = {
+    <field extends targetField>(
+      props: Expand<
+        componentProps<
+          def,
+          value,
+          targetStep,
+          field,
+          customProps,
+          additionalProps
+        > & { field: field }
+      >,
+    ): ReactNode;
+
+    /** Binds one field from a selectable implementation to a reusable component. */
+    asReusable<field extends targetField>(
+      field: field,
+    ): boundComponent<
+      def,
+      value,
+      targetStep,
+      field,
+      customProps,
+      additionalProps
+    >;
+  };
+
+  export interface createComponentFn<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    additionalProps extends object = {},
+  > {
+    <
+      targetStep extends StepNumbers<value>,
+      targetField extends getDeepFields<value, targetStep>,
+      customProps extends object = {},
+    >(
+      config: StepSpecificComponent.fieldConfig<
+        def,
+        value,
+        targetStep,
+        targetField,
+        customProps
+      > & { step: targetStep },
+    ): boundComponent<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps,
+      additionalProps
+    >;
+
+    <
+      targetStep extends StepNumbers<value>,
+      targetField extends getDeepFields<value, targetStep>,
+      customProps extends object = {},
+    >(
+      config: StepSpecificComponent.selectableFieldConfig<
+        def,
+        value,
+        targetStep,
+        targetField,
+        customProps
+      > & { fields: readonly targetField[]; step: targetStep },
+    ): selectableComponent<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps,
+      additionalProps
+    >;
+
+    <
+      targetStep extends StepNumbers<value>,
+      customProps extends object = {},
+    >(
+      config: Omit<
+        StepSpecificComponent.selectableFieldConfig<
+          def,
+          value,
+          targetStep,
+          getDeepFields<value, targetStep>,
+          customProps
+        >,
+        'fields'
+      > & { fields?: undefined; step: targetStep },
+    ): selectableComponent<
+      def,
+      value,
+      targetStep,
+      getDeepFields<value, targetStep>,
+      customProps,
+      additionalProps
+    >;
+  }
+
+  export interface stepCreateComponentFn<
+    def extends StepSchema.Config,
+    value extends instantiateReactSteps<def>,
+    targetStep extends StepNumbers<value>,
+    additionalProps extends object = {},
+  > {
+    <
+      targetField extends getDeepFields<value, targetStep>,
+      customProps extends object = {},
+    >(
+      config: StepSpecificComponent.fieldConfig<
+        def,
+        value,
+        targetStep,
+        targetField,
+        customProps
+      >,
+    ): boundComponent<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps,
+      additionalProps
+    >;
+
+    <
+      targetField extends getDeepFields<value, targetStep>,
+      customProps extends object = {},
+    >(
+      config: StepSpecificComponent.selectableFieldConfig<
+        def,
+        value,
+        targetStep,
+        targetField,
+        customProps
+      > & { fields: readonly targetField[] },
+    ): selectableComponent<
+      def,
+      value,
+      targetStep,
+      targetField,
+      customProps,
+      additionalProps
+    >;
+
+    <customProps extends object = {}>(
+      config: Omit<
+        StepSpecificComponent.selectableFieldConfig<
+          def,
+          value,
+          targetStep,
+          getDeepFields<value, targetStep>,
+          customProps
+        >,
+        'fields'
+      > & { fields?: undefined },
+    ): selectableComponent<
+      def,
+      value,
+      targetStep,
+      getDeepFields<value, targetStep>,
+      customProps,
+      additionalProps
+    >;
+  }
+}
+
+type SelectableComponent = (
+  props: Record<string, unknown>,
+) => ReactNode;
+
+export function withReusableField<Component extends SelectableComponent>(
+  Component: Component,
+) {
+  function asReusable(field: string) {
+    return function ReusableField(props: Record<string, unknown> = {}) {
+      return createElement(Component as never, { ...props, field } as never);
+    };
+  }
+
+  return Object.assign(Component, { asReusable });
+}

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -23,6 +23,7 @@ import {
   type StepSchema,
 } from '@jfdevelops/multi-step-form-core/_internals';
 import { field } from './field';
+import { ForField, withReusableField } from './for-field';
 import { MultiStepFormSchemaConfig } from './form-config';
 import { createUseSelector, deepEqual } from './hooks/use-selector';
 import { selector } from './selector';
@@ -59,77 +60,8 @@ export interface CreateComponentFn<
     },
   ): CreatedMultiStepFormComponent<props>;
 
-  /**
-   * Creates a reusable component bound to one field in one step.
-   * Field metadata and current values are passed to `render`; remaining component props are
-   * forwarded as its optional custom props argument.
-   */
-  forField<
-    targetStep extends StepNumbers<value>,
-    targetField extends getDeepFields<value, targetStep>,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.fieldConfig<
-      def,
-      value,
-      targetStep,
-      targetField,
-      customProps
-    > & { step: targetStep },
-  ): StepSpecificComponent.fieldComponent<
-    def,
-    value,
-    targetStep,
-    targetField,
-    customProps
-  >;
+  forField: ForField.createComponentFn<def, value>;
 
-  /**
-   * Creates a reusable component that selects a field from one step when rendered.
-   * The returned component requires `field`, while field metadata and current values are
-   * passed to `render`.
-   */
-  forField<
-    targetStep extends StepNumbers<value>,
-    targetField extends getDeepFields<value, targetStep>,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.selectableFieldConfig<
-      def,
-      value,
-      targetStep,
-      targetField,
-      customProps
-    > & { fields: readonly targetField[]; step: targetStep },
-  ): StepSpecificComponent.selectableFieldComponent<
-    def,
-    value,
-    targetStep,
-    targetField,
-    customProps
-  >;
-
-  forField<
-    targetStep extends StepNumbers<value>,
-    customProps extends object = {},
-  >(
-    config: Omit<
-      StepSpecificComponent.selectableFieldConfig<
-        def,
-        value,
-        targetStep,
-        getDeepFields<value, targetStep>,
-        customProps
-      >,
-      'fields'
-    > & { fields?: undefined; step: targetStep },
-  ): StepSpecificComponent.selectableFieldComponent<
-    def,
-    value,
-    targetStep,
-    getDeepFields<value, targetStep>,
-    customProps
-  >;
 }
 
 export interface HelperFunctions<
@@ -271,7 +203,7 @@ export class MultiStepFormStepSchema<
 
         return target.createComponent.forField(fieldConfig as never);
       },
-    }) as CreateComponentFn<def, value>;
+    }) as unknown as CreateComponentFn<def, value>;
   }
 
   private createResolvedCtx<
@@ -744,7 +676,7 @@ export class MultiStepFormStepSchema<
       // validation, deep-field support, and update/reset behavior. When the configuration omits
       // a field, ownership moves to the returned component so one implementation can serve every
       // compatible field in the step.
-      return impl({
+      const Component = impl({
         render: (
           { Field }: StepSpecificComponent.input<def, value, targetStep, {}>,
           componentProps: StepSpecificComponent.fieldComponentProps<
@@ -794,9 +726,11 @@ export class MultiStepFormStepSchema<
           );
         },
       } as never);
+
+      return withReusableField(Component as never);
     };
 
-    return Object.assign(impl, { forField }) as StepSpecificCreateComponentFn<
+    return Object.assign(impl, { forField }) as unknown as StepSpecificCreateComponentFn<
       def,
       value,
       targetStep

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -57,55 +57,70 @@ export namespace StepSpecificComponent {
     >]: Expand<getDefaultValues<value, step>>;
   };
 
-  type keysOfUnion<value> = value extends value ? keyof value : never;
-  type valueForKey<value, key extends PropertyKey> = value extends value
-    ? key extends keyof value
-      ? value[key]
-      : never
-    : never;
   type stepsContainingField<
-    grouped,
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
     field extends PropertyKey,
   > = {
-    [step in keyof grouped]: field extends keyof grouped[step] ? step : never;
-  }[keyof grouped];
+    [step in HelperFnChosenSteps.resolve<
+      value,
+      chosenSteps
+    >]: field extends keyof getDefaultValues<value, step> ? step : never;
+  }[HelperFnChosenSteps.resolve<value, chosenSteps>];
   type isUnion<value, original = value> = value extends original
     ? [original] extends [value]
       ? false
       : true
     : never;
   type groupedFieldValues<
-    grouped,
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
     field extends PropertyKey,
   > = Expand<{
-    [step in stepsContainingField<grouped, field>]: field extends keyof grouped[step]
-      ? grouped[step][field]
+    [step in stepsContainingField<
+      value,
+      chosenSteps,
+      field
+    >]: field extends keyof getDefaultValues<value, step>
+      ? getDefaultValues<value, step>[field]
       : never;
   }>;
-  type flatFieldValue<grouped, field extends PropertyKey> = isUnion<
-    stepsContainingField<grouped, field>
+  type selectedFieldNames<
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+  > = {
+    [step in HelperFnChosenSteps.resolve<
+      value,
+      chosenSteps
+    >]: keyof getDefaultValues<value, step>;
+  }[HelperFnChosenSteps.resolve<value, chosenSteps>];
+  type flatFieldValue<
+    value extends instantiateReactSteps,
+    chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
+    field extends PropertyKey,
+  > = isUnion<
+    stepsContainingField<value, chosenSteps, field>
   > extends true
-    ? groupedFieldValues<grouped, field>
-    : valueForKey<grouped[keyof grouped], field>;
+    ? groupedFieldValues<value, chosenSteps, field>
+    : groupedFieldValues<value, chosenSteps, field> extends infer values
+      ? values[keyof values]
+      : never;
 
   export type multiStepDefaultValues<
     value extends instantiateReactSteps,
     chosenSteps extends HelperFnChosenSteps.main<value, StepNumbers<value>>,
-    grouped extends selectedDefaultValues<value, chosenSteps> = selectedDefaultValues<
-      value,
-      chosenSteps
-    >,
   > = {
     /** Default field values grouped under their selected step keys. */
-    grouped: Expand<grouped>;
+    grouped: Expand<selectedDefaultValues<value, chosenSteps>>;
     /**
      * Default field values from every selected step merged into one object.
      * A field name declared by multiple selected steps is grouped under those step keys so no
      * value is overwritten.
      */
     flat: Expand<{
-      [field in keysOfUnion<grouped[keyof grouped]>]: flatFieldValue<
-        grouped,
+      [field in selectedFieldNames<value, chosenSteps>]: flatFieldValue<
+        value,
+        chosenSteps,
         field
       >;
     }>;
@@ -426,22 +441,6 @@ export namespace StepSpecificComponent {
       Omit<customProps, 'name' | 'children'>
   >;
 
-  export type fieldComponent<
-    def extends StepSchema.Config,
-    value extends instantiateReactSteps<def>,
-    targetStep extends StepNumbers<value>,
-    targetField extends getDeepFields<value, targetStep>,
-    customProps extends object,
-  > = (
-    props: fieldComponentProps<
-      def,
-      value,
-      targetStep,
-      targetField,
-      customProps
-    >,
-  ) => ReactNode;
-
   export type selectableFieldComponentProps<
     def extends StepSchema.Config,
     value extends instantiateReactSteps<def>,
@@ -460,22 +459,6 @@ export namespace StepSpecificComponent {
       field: targetField;
     }
   >;
-
-  export type selectableFieldComponent<
-    def extends StepSchema.Config,
-    value extends instantiateReactSteps<def>,
-    targetStep extends StepNumbers<value>,
-    targetField extends getDeepFields<value, targetStep>,
-    customProps extends object,
-  > = (
-    props: selectableFieldComponentProps<
-      def,
-      value,
-      targetStep,
-      targetField,
-      customProps
-    >,
-  ) => ReactNode;
 
   export type fieldConfig<
     def extends StepSchema.Config,
@@ -571,66 +554,10 @@ export interface StepSpecificCreateComponentFn<
    * Field metadata and current values are passed to `render`; remaining component props are
    * forwarded as its optional custom props argument.
    */
-  forField<
-    targetField extends getDeepFields<value, targetStep>,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.fieldConfig<
-      def,
-      value,
-      targetStep,
-      targetField,
-      customProps
-    >,
-  ): StepSpecificComponent.fieldComponent<
+  forField: import('./for-field').ForField.stepCreateComponentFn<
     def,
     value,
-    targetStep,
-    targetField,
-    customProps
-  >;
-
-  /**
-   * Creates a reusable component that selects one of this step's fields when rendered.
-   * The returned component requires `field`, while field metadata and current values are
-   * passed to `render`.
-   */
-  forField<
-    targetField extends getDeepFields<value, targetStep>,
-    customProps extends object = {},
-  >(
-    config: StepSpecificComponent.selectableFieldConfig<
-      def,
-      value,
-      targetStep,
-      targetField,
-      customProps
-    > & { fields: readonly targetField[] },
-  ): StepSpecificComponent.selectableFieldComponent<
-    def,
-    value,
-    targetStep,
-    targetField,
-    customProps
-  >;
-
-  forField<customProps extends object = {}>(
-    config: Omit<
-      StepSpecificComponent.selectableFieldConfig<
-        def,
-        value,
-        targetStep,
-        getDeepFields<value, targetStep>,
-        customProps
-      >,
-      'fields'
-    > & { fields?: undefined },
-  ): StepSpecificComponent.selectableFieldComponent<
-    def,
-    value,
-    targetStep,
-    getDeepFields<value, targetStep>,
-    customProps
+    targetStep
   >;
 }
 

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -209,6 +209,50 @@ describe('creating components via "createComponent" fn', () => {
       );
     });
 
+    it('only groups duplicate flat keys under the steps that declare them', () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Contact',
+            fields: {
+              firstName: { defaultValue: 'Taylor' },
+              lastName: { defaultValue: 'Client' },
+            },
+          },
+          step2: {
+            title: 'Account',
+            fields: { email: { defaultValue: 'client@example.com' } },
+          },
+          step3: {
+            title: 'Preferences',
+            fields: {
+              firstName: { defaultValue: false },
+              age: { defaultValue: 30 },
+            },
+          },
+          step4: {
+            title: 'Confirmation',
+            fields: { accepted: { defaultValue: true } },
+          },
+        },
+      }).configure()();
+
+      schema.createComponent({
+        stepData: 'all',
+        render({ defaultValues }) {
+          expectTypeOf(defaultValues.flat).toEqualTypeOf<{
+            firstName: { step1: string; step3: boolean };
+            lastName: string;
+            email: string;
+            age: number;
+            accepted: boolean;
+          }>();
+
+          return null;
+        },
+      });
+    });
+
     it('provides grouped and flat default values for multiple selected steps', async () => {
       const schema = defineMultiStepForm({
         steps: {

--- a/packages/react/test/step-schema/for-field.test.tsx
+++ b/packages/react/test/step-schema/for-field.test.tsx
@@ -132,6 +132,29 @@ describe('createComponent.forField', () => {
 
       expect(screen.getByText('Client')).toBeDefined();
     });
+
+    it('binds a selectable implementation to a reusable target field', async () => {
+      const schema = fieldFormDefinition.configure()({ instance: 'client' });
+      const FieldValue = schema.createComponent.forField({
+        step: 'step1',
+        fields: ['firstName', 'email'],
+        render(field, props: { prefix: string }) {
+          return <p>{props.prefix}:{field.defaultValue}</p>;
+        },
+      });
+      const FirstName = FieldValue.asReusable('firstName');
+
+      type FirstNameProps = ComponentPropsWithRef<typeof FirstName>;
+      expectTypeOf<'field'>().not.toMatchTypeOf<keyof FirstNameProps>();
+      expectTypeOf<{ prefix: string }>().toMatchTypeOf<FirstNameProps>();
+
+      // @ts-expect-error The selector limits reusable targets to its configured fields.
+      FieldValue.asReusable('lastName');
+
+      const screen = await renderInJsdom(<FirstName prefix='Name' />);
+
+      expect(screen.getByText('Name:Taylor')).toBeDefined();
+    });
   });
 
   describe('configured step createComponent', () => {
@@ -261,6 +284,31 @@ describe('createComponent.forField', () => {
       );
 
       expect(screen.getByText('Client override')).toBeDefined();
+    });
+
+    it('binds a factory implementation while preserving the instance prop', async () => {
+      const createForm = fieldFormDefinition.configure();
+      const schema = createForm({ instance: 'client' });
+      const FieldValue = createForm.createComponent.forField({
+        step: 'step1',
+        render(field, props: { prefix: string }) {
+          return <p>{props.prefix}:{field.defaultValue}</p>;
+        },
+      });
+      const Email = FieldValue.asReusable('email');
+
+      type EmailProps = ComponentPropsWithRef<typeof Email>;
+      expectTypeOf<{
+        instance: typeof schema;
+        prefix: string;
+      }>().toMatchTypeOf<EmailProps>();
+      expectTypeOf<'field'>().not.toMatchTypeOf<keyof EmailProps>();
+
+      const screen = await renderInJsdom(
+        <Email instance={schema} prefix='Email' />,
+      );
+
+      expect(screen.getByText('Email:client@example.com')).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- keep unique `defaultValues.flat` entries as direct values while grouping only duplicated field names by their declaring steps
- normalize configured-schema and definition-factory `forField` types through a shared module
- preserve the generic selected `field` type and add `asReusable(field)` for field-bound shared components
- make the React test script run once by default and retain watch mode through `test:watch`

## Root cause

The flat-value type operated on a union of grouped step values, which lost the correlation between each field and the steps that declared it. The `forField` contracts were also duplicated across schema and factory surfaces, allowing their inference behavior to diverge. Separately, the React package used bare `vitest`, so interactive terminals entered watch mode and appeared to hang.

## Impact

Consumers now receive the expected flat default-value shape, duplicate fields retain their per-step value types, and reusable field components share one consistent generic API. React test commands also terminate normally unless watch mode is explicitly requested.

## Validation

- package pre-commit test suites: 236 tests passed across Core and React
- package typechecks passed
- package and React example builds passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public React form typing and the reusable `forField` component API, so consumer type inference and component usage can change. No auth, storage, or runtime data-path changes beyond attaching `asReusable`.
> 
> **Overview**
> Fixes multi-step `defaultValues.flat` typing so **unique field names stay as direct values**, while only duplicated names are grouped under the steps that declare them.
> 
> Consolidates schema and factory `createComponent.forField` contracts into a shared `for-field` module, and adds **`asReusable(field)`** so selectable field components can be bound to one field without passing `field` at render time.
> 
> Also makes the React package `test` script run once by default (`vitest run`) and moves watch mode to `test:watch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000bd64e7e1ae747fd0fecd4cd2c92d63ab96b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->