### PR TITLE
fix: centralize form metadata and override APIs

### DIFF
--- a/.changeset/core-value-overrides.md
+++ b/.changeset/core-value-overrides.md
@@ -1,0 +1,6 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Add the core `createValueOverride` factory API and immediately run overrides attached with `withOverrides`.

--- a/.changeset/default-overrides.md
+++ b/.changeset/default-overrides.md
@@ -1,0 +1,6 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Add configured `defaultOverrides` that run for every form instance.

--- a/.changeset/full-field-metadata.md
+++ b/.changeset/full-field-metadata.md
@@ -1,0 +1,6 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Preserve complete resolved field metadata across public core and React helpers.

--- a/.changeset/nested-flat-defaults.md
+++ b/.changeset/nested-flat-defaults.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Deeply expand nested field default values in the `defaultValues.flat` type.

--- a/packages/core/src/define.ts
+++ b/packages/core/src/define.ts
@@ -105,7 +105,10 @@ export type ConfigureOptions<
   // `DefineConfig` / `StepSchema.Config`. Call sites that want the runtime default pass
   // `DefaultCasing` explicitly (see {@linkcode MultiStepFormDefinition.configure}).
   TCasing extends CasingType = CasingType,
+  TSteps extends StepConfig = StepConfig,
 > = NameTransformCasingOptions<TCasing> & {
+  /** Override resolvers applied to every instance created by this factory. */
+  defaultOverrides?: WithOverridesMap<TSteps>;
   storage?: ConfigureStorageConfig<InstanceName<TInstances>>;
   update?: ConfigureUpdateConfig<InstanceName<TInstances>>;
 };
@@ -139,6 +142,23 @@ export function mergeStepOverrides<TSteps extends StepConfig>(
       ];
     }),
   ) as TSteps;
+}
+
+interface OverrideResolvable {
+  stepSchema: {
+    resolveOverrides(): unknown;
+  };
+}
+
+export function scheduleOverrideResolution<TInstance extends OverrideResolvable>(
+  instance: TInstance,
+  getCurrentInstance: () => TInstance | undefined,
+) {
+  queueMicrotask(() => {
+    if (getCurrentInstance() === instance) {
+      instance.stepSchema.resolveOverrides();
+    }
+  });
 }
 
 /**
@@ -346,10 +366,11 @@ export type MultiStepFormFactory<
 function resolveStorageConfig<
   TInstances extends readonly string[] | undefined,
   TCasing extends CasingType,
+  TSteps extends StepConfig,
 >(
   instanceName: InstanceName<TInstances>,
   declaredInstances: TInstances,
-  configureOptions: ConfigureOptions<TInstances, TCasing>,
+  configureOptions: ConfigureOptions<TInstances, TCasing, TSteps>,
 ): BaseStorageConfig<string> {
   const { storage, update } = configureOptions;
   const configuredInstances: readonly InstanceName<TInstances>[] =
@@ -396,10 +417,11 @@ function createFactory<
   const TCasing extends CasingType,
 >(
   config: DefineMultiStepFormOptions<TSteps, TInstances>,
-  configureOptions: ConfigureOptions<TInstances, TCasing>,
+  configureOptions: ConfigureOptions<TInstances, TCasing, TSteps>,
 ): MultiStepFormFactory<TSteps, TInstances, TCasing> {
   const { steps, instances: declaredInstances } = config;
-  const { nameTransformCasing } = configureOptions;
+  const { defaultOverrides, nameTransformCasing } = configureOptions;
+  const configuredSteps = mergeStepOverrides(steps as TSteps, defaultOverrides);
   const registry = new Map<
     InstanceName<TInstances>,
     MultiStepFormInstanceImpl<DefineConfig<TSteps, TCasing>>
@@ -423,7 +445,7 @@ function createFactory<
     const instance = new MultiStepFormInstanceImpl<
       DefineConfig<TSteps, TCasing>
     >({
-      steps: steps as DefineConfig<TSteps, TCasing>['steps'],
+      steps: configuredSteps as DefineConfig<TSteps, TCasing>['steps'],
       nameTransformCasing,
       storageConfig,
       instanceName,
@@ -431,6 +453,7 @@ function createFactory<
     });
 
     setActive(instanceName, instance);
+    scheduleOverrideResolution(instance, () => registry.get(instanceName));
 
     return instance;
   }
@@ -533,8 +556,9 @@ export class MultiStepFormDefinition<
   configure<const TCasing extends CasingType = DefaultCasing>(
     configureOptions: ConfigureOptions<
       TInstances,
-      TCasing
-    > = {} as ConfigureOptions<TInstances, TCasing>,
+      TCasing,
+      TSteps
+    > = {} as ConfigureOptions<TInstances, TCasing, TSteps>,
   ): MultiStepFormFactory<TSteps, TInstances, TCasing> {
     return createFactory<TSteps, TInstances, TCasing>(
       this.config,

--- a/packages/core/src/define.ts
+++ b/packages/core/src/define.ts
@@ -1,7 +1,10 @@
 import { InvalidInstanceError } from '@/errors/invalid-instance';
 import { NoActiveInstanceError } from '@/errors/no-active-instance';
 import { MultiStepFormSchema } from '@/schema';
-import type { NameTransformCasingOptions } from '@/steps/fields';
+import type {
+  getDefaultValues,
+  NameTransformCasingOptions,
+} from '@/steps/fields';
 import type { StepSpecificHelperFn } from '@/steps/fn-utils/helper-fn/utils';
 import {
   instantiateSteps,
@@ -13,7 +16,13 @@ import {
 } from '@/steps/steps';
 import { functionalUpdate } from '@/steps/utils';
 import { DEFAULT_STORAGE_KEY, type BaseStorageConfig } from '@/storage';
-import type { CasingType, DefaultCasing, Updater } from '@/utils';
+import type {
+  CasingType,
+  DefaultCasing,
+  Expand,
+  stripFunctions,
+  Updater,
+} from '@/utils';
 
 /**
  * The name used for the single instance created when {@linkcode DefineMultiStepFormOptions.instances}
@@ -106,6 +115,31 @@ export type WithOverridesMap<TSteps extends StepConfig> = Partial<{
     key in keyof TSteps as string extends key ? never : key
   ]: TSteps[key] extends AnyConfig ? StepOverrides<TSteps[key]> : never;
 }>;
+
+export function mergeStepOverrides<TSteps extends StepConfig>(
+  steps: TSteps,
+  overrides: WithOverridesMap<TSteps> | undefined,
+) {
+  if (!overrides) {
+    return steps;
+  }
+
+  return Object.fromEntries(
+    Object.entries(steps as Record<string, object>).map(([key, stepConfig]) => {
+      const override = (overrides as Record<string, unknown>)[key];
+
+      return [
+        key,
+        override
+          ? {
+              ...stepConfig,
+              overrides: override,
+            }
+          : stepConfig,
+      ];
+    }),
+  ) as TSteps;
+}
 
 /**
  * The resolved instantiated value shape for a form definition's steps, independent of any
@@ -207,23 +241,7 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
   }
 
   withOverrides(overrides: WithOverridesMap<def['steps']>) {
-    const mergedSteps = Object.fromEntries(
-      Object.entries(this.#rawSteps as Record<string, object>).map(
-        ([key, stepConfig]) => {
-          const override = (overrides as Record<string, unknown>)[key];
-
-          return [
-            key,
-            override
-              ? {
-                  ...stepConfig,
-                  overrides: override,
-                }
-              : stepConfig,
-          ];
-        },
-      ),
-    ) as def['steps'];
+    const mergedSteps = mergeStepOverrides(this.#rawSteps, overrides);
 
     const next = new MultiStepFormInstanceImpl<def>({
       steps: mergedSteps,
@@ -234,6 +252,8 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
     });
 
     this.#onRebuild(next);
+
+    next.stepSchema.resolveOverrides();
 
     return next as unknown as MultiStepFormInstance<def>;
   }
@@ -264,6 +284,30 @@ export interface MultiStepFormFactoryStepFunctions<
   createHelperFn: StepSpecificHelperFn<DefineValue<TSteps>, key>;
 }
 
+export interface MultiStepFormFactoryCreateValueOverrideFn<
+  TSteps extends StepConfig,
+> {
+  <targetStep extends StepNumbers<DefineValue<TSteps>>>(options: {
+    step: targetStep;
+    values: (
+      data: Expand<stripFunctions<DefineValue<TSteps>[targetStep]>>,
+    ) =>
+      | Partial<getDefaultValues<DefineValue<TSteps>, targetStep>>
+      | Promise<Partial<getDefaultValues<DefineValue<TSteps>, targetStep>>>;
+  }): (
+    data: Expand<stripFunctions<DefineValue<TSteps>[targetStep]>>,
+  ) =>
+    | Partial<getDefaultValues<DefineValue<TSteps>, targetStep>>
+    | Promise<Partial<getDefaultValues<DefineValue<TSteps>, targetStep>>>;
+}
+
+export function createValueOverride<data, result>(options: {
+  step: string;
+  values: (data: data) => result;
+}) {
+  return (data: data) => options.values(data);
+}
+
 export type MultiStepFormFactoryStepProperties<TSteps extends StepConfig> = {
   [key in StepNumbers<DefineValue<TSteps>>]: MultiStepFormFactoryStepFunctions<
     TSteps,
@@ -275,6 +319,8 @@ export type MultiStepFormFactoryBase<
   TSteps extends StepConfig,
   TInstances extends readonly string[] | undefined,
 > = MultiStepFormFactoryStepProperties<TSteps> & {
+  /** Creates a typed value override resolver for one step. */
+  createValueOverride: MultiStepFormFactoryCreateValueOverrideFn<TSteps>;
   /**
    * Explicitly sets the active instance (the instance shared `createHelperFn`s dispatch to).
    *
@@ -450,6 +496,7 @@ function createFactory<
   );
 
   return Object.assign(factory, stepHelpers, {
+    createValueOverride,
     setActiveInstance(instanceName: InstanceName<TInstances>) {
       InvalidInstanceError.invariant(registry.has(instanceName), {
         reason: `"${instanceName}" has not been created yet. Call the factory with this instance first.`,

--- a/packages/core/src/steps/fields.ts
+++ b/packages/core/src/steps/fields.ts
@@ -370,6 +370,25 @@ type instantiateResolvedErrorMessageProp<T> = T extends {
 }
   ? { errorMessage: string }
   : {};
+type instantiateFieldMetadata<T> = T extends object
+  ? Omit<
+      T,
+      | 'defaultValue'
+      | 'label'
+      | 'nameTransformCasing'
+      | 'isRequired'
+      | 'placeholder'
+      | 'errorMessage'
+      | 'type'
+    >
+  : {};
+type instantiateResolvedTypeProp<T> = 'type' extends keyof T
+  ? T extends object
+    ? T['type'] extends infer type extends string
+      ? { type: type }
+      : {}
+    : {}
+  : {};
 export type inferResolvedDateFieldType<T> = T extends {
   type: infer type extends DateFieldType;
 }
@@ -382,7 +401,7 @@ export type instantiateFields<
   ? T extends instantiateConfig
     ? {
         -readonly [key in keyof T['fields']]: Expand<
-          {
+          instantiateFieldMetadata<T['fields'][key]> & {
             /**
              * The default value for the field.
              */
@@ -411,6 +430,7 @@ export type instantiateFields<
             : {}) &
             instantiateResolvedPlaceholderProp<T['fields'][key]> &
             instantiateResolvedErrorMessageProp<T['fields'][key]> &
+            instantiateResolvedTypeProp<T['fields'][key]> &
             (inferDefaultValue<T['fields'][key]> extends Date
               ? /**
                  * The type of the field.
@@ -522,17 +542,21 @@ export function instantiateFields<
       },
     );
 
-    const { defaultValue, label, nameTransformCasing, placeholder, isRequired, errorMessage } =
-      values;
+    const {
+      defaultValue,
+      label,
+      nameTransformCasing,
+      isRequired,
+      ...metadata
+    } = values;
     const casing = nameTransformCasing ?? defaultCasing ?? DEFAULT_CASING;
     const resolvedLabel = createFieldLabel(label, name, casing, Boolean(isRequired));
     const sharedFields = {
+      ...metadata,
       nameTransformCasing: casing,
       name,
       isRequired: Boolean(isRequired),
       ...(resolvedLabel === undefined ? {} : { label: resolvedLabel }),
-      ...(placeholder === undefined ? {} : { placeholder }),
-      ...(errorMessage === undefined ? {} : { errorMessage }),
     };
 
     if (defaultValue instanceof Date) {

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -777,6 +777,16 @@ export class MultiStepFormStepSchema<
     return this.value[step];
   }
 
+  resolveOverrides(
+    steps = Object.keys(this.value) as StepNumbers<value>[],
+  ) {
+    for (const step of steps) {
+      void this.resolveStep(step).catch(() => {
+        // Resolution errors remain available through the public step error state.
+      });
+    }
+  }
+
   suspendStep<targetStep extends StepNumbers<value>>(step: targetStep) {
     if (!this.hasOverrides(step)) {
       return this.value[step];

--- a/packages/core/test/field-metadata-and-is-complete.test.ts
+++ b/packages/core/test/field-metadata-and-is-complete.test.ts
@@ -93,6 +93,45 @@ describe('field metadata: placeholder, isRequired, errorMessage', () => {
     expectTypeOf(field.placeholder).toEqualTypeOf<string>();
     expectTypeOf(field.errorMessage).toEqualTypeOf<string>();
   });
+
+  it('makes all field metadata available to public helper callbacks', () => {
+    const createForm = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            email: {
+              defaultValue: '',
+              placeholder: 'name@example.com',
+              isRequired: true,
+              errorMessage: 'Enter a valid email',
+              type: 'string.email',
+            },
+          },
+        },
+      },
+    }).configure();
+    const instance = createForm();
+    const readMetadata = instance.stepSchema.value.step1.createHelperFn(
+      ({ ctx }) => {
+        const field = ctx.step1.fields.email;
+
+        expectTypeOf(field.placeholder).toEqualTypeOf<string>();
+        expectTypeOf(field.isRequired).toEqualTypeOf<true>();
+        expectTypeOf(field.errorMessage).toEqualTypeOf<string>();
+        expectTypeOf(field.type).toEqualTypeOf<'string.email'>();
+
+        return field;
+      },
+    );
+
+    expect(readMetadata()).toMatchObject({
+      placeholder: 'name@example.com',
+      isRequired: true,
+      errorMessage: 'Enter a valid email',
+      type: 'string.email',
+    });
+  });
 });
 
 describe('step isComplete', () => {

--- a/packages/core/test/step-schema/overrides.test.ts
+++ b/packages/core/test/step-schema/overrides.test.ts
@@ -2,6 +2,48 @@ import { describe, expect, it, vi } from 'vitest';
 import { defineMultiStepForm } from '../../src';
 
 describe('multi step form step schema: overrides', () => {
+  it('applies default overrides to every instance and preserves them beside instance overrides', async () => {
+    const pretendServer = {
+      getSharedName: vi.fn(async () => ({ firstName: 'Server default' })),
+      getSharedAge: vi.fn(async () => ({ age: 42 })),
+      getClientName: vi.fn(async () => ({ firstName: 'Client' })),
+    };
+    const createForm = defineMultiStepForm({
+      instances: ['client', 'admin'],
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: { firstName: { defaultValue: '' } },
+        },
+        step2: {
+          title: 'Step 2',
+          fields: { age: { defaultValue: 0 } },
+        },
+      },
+    }).configure({
+      defaultOverrides: {
+        step1: async () => pretendServer.getSharedName(),
+        step2: async () => pretendServer.getSharedAge(),
+      },
+    });
+    const client = createForm({ instance: 'client' }).withOverrides({
+      step1: async () => pretendServer.getClientName(),
+    });
+    const admin = createForm({ instance: 'admin' });
+
+    await vi.waitFor(() => {
+      expect(client.stepSchema.getValue('step1', 'firstName')).toBe('Client');
+      expect(client.stepSchema.getValue('step2', 'age')).toBe(42);
+      expect(admin.stepSchema.getValue('step1', 'firstName')).toBe(
+        'Server default',
+      );
+      expect(admin.stepSchema.getValue('step2', 'age')).toBe(42);
+    });
+    expect(pretendServer.getSharedName).toHaveBeenCalledTimes(1);
+    expect(pretendServer.getSharedAge).toHaveBeenCalledTimes(2);
+    expect(pretendServer.getClientName).toHaveBeenCalledTimes(1);
+  });
+
   it('creates and automatically runs typed value overrides from the core factory', async () => {
     const createForm = defineMultiStepForm({
       steps: {

--- a/packages/core/test/step-schema/overrides.test.ts
+++ b/packages/core/test/step-schema/overrides.test.ts
@@ -1,7 +1,40 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { defineMultiStepForm } from '../../src';
 
 describe('multi step form step schema: overrides', () => {
+  it('creates and automatically runs typed value overrides from the core factory', async () => {
+    const createForm = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            profile: {
+              defaultValue: { name: 'Taylor', active: false },
+              type: 'object.profile',
+            },
+          },
+        },
+      },
+    }).configure();
+    const override = createForm.createValueOverride({
+      step: 'step1',
+      values: ({ fields }) => ({
+        profile: {
+          name: fields.profile.defaultValue.name,
+          active: true,
+        },
+      }),
+    });
+    const schema = createForm().withOverrides({ step1: override });
+
+    await vi.waitFor(() => {
+      expect(schema.stepSchema.getValue('step1', 'profile')).toEqual({
+        name: 'Taylor',
+        active: true,
+      });
+    });
+  });
+
   it('resolves async overrides for a single step', async () => {
     const createForm = defineMultiStepForm({
       steps: {
@@ -30,7 +63,7 @@ describe('multi step form step schema: overrides', () => {
       }),
     });
 
-    expect(schema.stepSchema.getStepStatus('step1')).toBe('idle');
+    expect(schema.stepSchema.getStepStatus('step1')).toBe('loading');
     expect(schema.stepSchema.getStepStatus('step2')).toBe('resolved');
     expect(schema.stepSchema.getValue('step1', 'firstName')).toBe('');
 

--- a/packages/core/test/step-schema/overrides.types.test.ts
+++ b/packages/core/test/step-schema/overrides.types.test.ts
@@ -2,6 +2,25 @@ import { describe, expectTypeOf, it } from 'vitest';
 import { defineMultiStepForm } from '../../src';
 
 describe('multi step form step schema: overrides types', () => {
+  it('infers default override data from configure options', () => {
+    defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: { firstName: { defaultValue: '' } },
+        },
+      },
+    }).configure({
+      defaultOverrides: {
+        step1: ({ fields }) => {
+          expectTypeOf(fields.firstName.defaultValue).toEqualTypeOf<string>();
+
+          return { firstName: 'Default' };
+        },
+      },
+    });
+  });
+
   it('infers createValueOverride data and return values from its target step', () => {
     const createForm = defineMultiStepForm({
       steps: {

--- a/packages/core/test/step-schema/overrides.types.test.ts
+++ b/packages/core/test/step-schema/overrides.types.test.ts
@@ -2,6 +2,37 @@ import { describe, expectTypeOf, it } from 'vitest';
 import { defineMultiStepForm } from '../../src';
 
 describe('multi step form step schema: overrides types', () => {
+  it('infers createValueOverride data and return values from its target step', () => {
+    const createForm = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            profile: {
+              defaultValue: { name: 'Taylor', active: false },
+              type: 'object.profile',
+            },
+          },
+        },
+      },
+    }).configure();
+
+    const override = createForm.createValueOverride({
+      step: 'step1',
+      values: ({ fields }) => {
+        expectTypeOf(fields.profile.type).toEqualTypeOf<'object.profile'>();
+        expectTypeOf(fields.profile.defaultValue).toEqualTypeOf<{
+          name: string;
+          active: boolean;
+        }>();
+
+        return { profile: { name: 'Jordan', active: true } };
+      },
+    });
+
+    createForm().withOverrides({ step1: override });
+  });
+
   it('infers override data as the resolved current step', () => {
     const createForm = defineMultiStepForm({
       steps: {

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -16,6 +16,7 @@ import {
   type InstanceName,
   mergeStepOverrides,
   type MultiStepFormFactoryCreateValueOverrideFn,
+  scheduleOverrideResolution,
   type StepConfig,
   type StepNumbers,
   type StepSpecificHelperFn,
@@ -152,10 +153,11 @@ function attachInstance<
 function resolveStorageConfig<
   TInstances extends readonly string[] | undefined,
   TCasing extends CasingType,
+  TSteps extends StepConfig,
 >(
   instanceName: InstanceName<TInstances>,
   declaredInstances: TInstances,
-  configureOptions: ConfigureOptions<TInstances, TCasing>,
+  configureOptions: ConfigureOptions<TInstances, TCasing, TSteps>,
 ): BaseStorageConfig<string> {
   const { storage, update } = configureOptions;
   const configuredInstances: readonly InstanceName<TInstances>[] =
@@ -397,10 +399,11 @@ function createReactFactory<
   const TCasing extends CasingType,
 >(
   config: DefineMultiStepFormOptions<TSteps, TInstances>,
-  configureOptions: ConfigureOptions<TInstances, TCasing>,
+  configureOptions: ConfigureOptions<TInstances, TCasing, TSteps>,
 ): MultiStepFormReactFactory<TSteps, TInstances, TCasing> {
   const { steps, instances: declaredInstances } = config;
-  const { nameTransformCasing } = configureOptions;
+  const { defaultOverrides, nameTransformCasing } = configureOptions;
+  const configuredSteps = mergeStepOverrides(steps as TSteps, defaultOverrides);
   const registry = new Map<
     InstanceName<TInstances>,
     MultiStepFormReactInstance<DefineConfig<TSteps, TCasing>>
@@ -408,7 +411,7 @@ function createReactFactory<
   const factorySchema = new MultiStepFormSchema<
     DefineConfig<TSteps, TCasing>
   >({
-    steps: steps as DefineConfig<TSteps, TCasing>['steps'],
+    steps: configuredSteps as DefineConfig<TSteps, TCasing>['steps'],
     nameTransformCasing,
     storage: {
       key: DEFAULT_STORAGE_KEY,
@@ -436,12 +439,12 @@ function createReactFactory<
       InstanceName<TInstances>
     >(
       new MultiStepFormSchema<DefineConfig<TSteps, TCasing>>({
-        steps: steps as DefineConfig<TSteps, TCasing>['steps'],
+        steps: configuredSteps as DefineConfig<TSteps, TCasing>['steps'],
         nameTransformCasing,
         storage: storageConfig,
       } as never),
       {
-        rawSteps: steps as DefineConfig<TSteps, TCasing>['steps'],
+        rawSteps: configuredSteps as DefineConfig<TSteps, TCasing>['steps'],
         nameTransformCasing,
         storageConfig,
         instanceName,
@@ -450,6 +453,7 @@ function createReactFactory<
     );
 
     setActive(instanceName, instance);
+    scheduleOverrideResolution(instance, () => registry.get(instanceName));
 
     return instance;
   }
@@ -648,8 +652,9 @@ export class MultiStepFormReactDefinition<
   configure<const TCasing extends CasingType = DefaultCasing>(
     configureOptions: ConfigureOptions<
       TInstances,
-      TCasing
-    > = {} as ConfigureOptions<TInstances, TCasing>,
+      TCasing,
+      TSteps
+    > = {} as ConfigureOptions<TInstances, TCasing, TSteps>,
   ): MultiStepFormReactFactory<TSteps, TInstances, TCasing> {
     return createReactFactory<TSteps, TInstances, TCasing>(
       this.config,

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -6,6 +6,7 @@ import {
   type BaseStorageConfig,
   type CasingType,
   type ConfigureOptions,
+  createValueOverride,
   type DefaultCasing,
   type DefineConfig,
   type DefineMultiStepFormOptions,
@@ -13,6 +14,8 @@ import {
   type HelperFnChosenSteps,
   InvalidComponentError,
   type InstanceName,
+  mergeStepOverrides,
+  type MultiStepFormFactoryCreateValueOverrideFn,
   type StepConfig,
   type StepNumbers,
   type StepSpecificHelperFn,
@@ -120,23 +123,7 @@ function attachInstance<
   return Object.assign(instance, {
     instanceName,
     withOverrides(overrides: WithOverridesMap<def['steps']>) {
-      const mergedSteps = Object.fromEntries(
-        Object.entries(rawSteps as Record<string, object>).map(
-          ([key, stepConfig]) => {
-            const override = (overrides as Record<string, unknown>)[key];
-
-            return [
-              key,
-              override
-                ? {
-                    ...stepConfig,
-                    overrides: override,
-                  }
-                : stepConfig,
-            ];
-          },
-        ),
-      ) as def['steps'];
+      const mergedSteps = mergeStepOverrides(rawSteps, overrides);
 
       const next = attachInstance<def, TInstance>(
         new MultiStepFormSchema<def>({
@@ -154,6 +141,8 @@ function attachInstance<
       );
 
       onRebuild(next);
+
+      next.stepSchema.resolveOverrides();
 
       return next;
     },
@@ -331,6 +320,11 @@ export type MultiStepFormReactFactoryBase<
 > &
   MultiStepFormReactFactoryStepProperties<TSteps> & {
   createComponent: MultiStepFormReactFactoryCreateComponentFn<TSteps, TCasing>;
+  /**
+   * Creates a typed value override resolver for one step that can be passed to
+   * {@linkcode MultiStepFormReactInstance.withOverrides}.
+   */
+  createValueOverride: MultiStepFormFactoryCreateValueOverrideFn<TSteps>;
   stepSchema: MultiStepFormReactFactoryStepSchema<TSteps, TCasing>;
   /**
    * Explicitly sets the active instance (the instance shared `createHelperFn`s dispatch to).
@@ -616,6 +610,7 @@ function createReactFactory<
     stepHelpers,
     {
       createComponent: sharedCreateComponent,
+      createValueOverride,
       setActiveInstance(instanceName: InstanceName<TInstances>) {
         InvalidInstanceError.invariant(registry.has(instanceName), {
           reason: `"${instanceName}" has not been created yet. Call the factory with this instance first.`,

--- a/packages/react/src/step-schema.ts
+++ b/packages/react/src/step-schema.ts
@@ -451,21 +451,16 @@ export class MultiStepFormStepSchema<
             const fieldName = String(name);
             const [parentFieldName] = fieldName.split('.');
             const fieldsRecord = currentStep.fields as Record<string, unknown>;
-            const { label, nameTransformCasing, type } = fieldsRecord[
-              parentFieldName
-            ] as {
-              label?: unknown;
-              nameTransformCasing?: unknown;
-              type?: unknown;
-            };
+            const fieldMetadata = fieldsRecord[parentFieldName] as Record<
+              string,
+              unknown
+            >;
 
             const targetFields = `fields.${builtValuePath}`;
 
             return {
+              ...fieldMetadata,
               defaultValue,
-              ...(label === undefined ? {} : { label }),
-              nameTransformCasing,
-              ...(type === undefined ? {} : { type }),
               name,
               onInputChange: <
                 strict extends boolean = true,

--- a/packages/react/src/steps.ts
+++ b/packages/react/src/steps.ts
@@ -105,6 +105,13 @@ export namespace StepSpecificComponent {
     : groupedFieldValues<value, chosenSteps, field> extends infer values
       ? values[keyof values]
       : never;
+  type expandDefaultValues<value> = value extends Date | Function
+    ? value
+    : value extends Array<infer item>
+      ? Array<expandDefaultValues<item>>
+      : value extends object
+        ? { [key in keyof value]: expandDefaultValues<value[key]> }
+        : value;
 
   export type multiStepDefaultValues<
     value extends instantiateReactSteps,
@@ -117,7 +124,7 @@ export namespace StepSpecificComponent {
      * A field name declared by multiple selected steps is grouped under those step keys so no
      * value is overwritten.
      */
-    flat: Expand<{
+    flat: expandDefaultValues<{
       [field in selectedFieldNames<value, chosenSteps>]: flatFieldValue<
         value,
         chosenSteps,

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -210,7 +210,7 @@ describe('creating components via "createComponent" fn', () => {
     });
 
     it('only groups duplicate flat keys under the steps that declare them', () => {
-      const schema = defineMultiStepForm({
+      const createForm = defineMultiStepForm({
         steps: {
           step1: {
             title: 'Contact',
@@ -235,9 +235,9 @@ describe('creating components via "createComponent" fn', () => {
             fields: { accepted: { defaultValue: true } },
           },
         },
-      }).configure()();
+      }).configure();
 
-      schema.createComponent({
+      createForm.createComponent({
         stepData: 'all',
         render({ defaultValues }) {
           expectTypeOf(defaultValues.flat).toEqualTypeOf<{
@@ -339,6 +339,36 @@ describe('creating components via "createComponent" fn', () => {
       });
 
       expect(field.textContent).toBe('step1.firstName:Jordan');
+    });
+
+    it('preserves nested object types in flat default values', () => {
+      const createForm = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Profile',
+            fields: {
+              profile: {
+                defaultValue: {
+                  name: { first: 'Taylor', last: 'Smith' },
+                  preferences: { notifications: true },
+                },
+              },
+            },
+          },
+        },
+      }).configure();
+
+      createForm.createComponent({
+        stepData: 'all',
+        render({ defaultValues }) {
+          expectTypeOf(defaultValues.flat.profile).toEqualTypeOf<{
+            name: { first: string; last: string };
+            preferences: { notifications: boolean };
+          }>();
+
+          return null;
+        },
+      });
     });
 
     it('preserves step helpers for a partial object step selector', async () => {

--- a/packages/react/test/step-schema/create-component.test.tsx
+++ b/packages/react/test/step-schema/create-component.test.tsx
@@ -407,6 +407,59 @@ describe('creating components via "createComponent" fn', () => {
   });
 
   describe('using step specific "createComponent" fn', () => {
+    it('passes all resolved field metadata to Field children', async () => {
+      const schema = defineMultiStepForm({
+        steps: {
+          step1: {
+            title: 'Contact',
+            fields: {
+              email: {
+                defaultValue: '',
+                placeholder: 'name@example.com',
+                isRequired: true,
+                errorMessage: 'Enter a valid email',
+                type: 'string.email',
+              },
+            },
+          },
+        },
+      }).configure()();
+      const fieldSpy = vi.fn();
+
+      expect(schema.stepSchema.original.step1.fields.email.type).toBe(
+        'string.email',
+      );
+      expect(schema.stepSchema.value.step1.fields.email).toMatchObject({
+        type: 'string.email',
+      });
+
+      const Step1 = schema.stepSchema.value.step1.createComponent({
+        render({ Field }) {
+          return (
+            <Field name='email'>
+              {(field) => {
+                expectTypeOf(field.type).toEqualTypeOf<'string.email'>();
+                fieldSpy(field);
+
+                return null;
+              }}
+            </Field>
+          );
+        },
+      });
+
+      await renderInJsdom(<Step1 />);
+
+      expect(fieldSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          placeholder: 'name@example.com',
+          isRequired: true,
+          errorMessage: 'Enter a valid email',
+          type: 'string.email',
+        }),
+      );
+    });
+
     it('should only use the default "ctx"', async () => {
       const schema = defineMultiStepForm({
         steps: {

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -70,6 +70,50 @@ function createDeferred<T>() {
 }
 
 describe('step overrides', () => {
+  it('loads default overrides from a server for every instance', async () => {
+    const pretendServer = {
+      getSharedName: vi.fn(async () => ({ firstName: 'Server default' })),
+      getSharedAge: vi.fn(async () => ({ age: 42 })),
+      getClientName: vi.fn(async () => ({ firstName: 'Client' })),
+    };
+    const createForm = defineMultiStepForm({
+      instances: ['client', 'admin'],
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: { firstName: { defaultValue: '' } },
+        },
+        step2: {
+          title: 'Step 2',
+          fields: { age: { defaultValue: 0 } },
+        },
+      },
+    }).configure({
+      defaultOverrides: {
+        step1: async () => pretendServer.getSharedName(),
+        step2: async () => pretendServer.getSharedAge(),
+      },
+    });
+    const client = createForm({ instance: 'client' }).withOverrides({
+      step1: async () => pretendServer.getClientName(),
+    });
+    const admin = createForm({ instance: 'admin' });
+
+    await vi.waitFor(() => {
+      expect(
+        client.stepSchema.value.step1.fields.firstName.defaultValue,
+      ).toBe('Client');
+      expect(client.stepSchema.value.step2.fields.age.defaultValue).toBe(42);
+      expect(admin.stepSchema.value.step1.fields.firstName.defaultValue).toBe(
+        'Server default',
+      );
+      expect(admin.stepSchema.value.step2.fields.age.defaultValue).toBe(42);
+    });
+    expect(pretendServer.getSharedName).toHaveBeenCalledTimes(1);
+    expect(pretendServer.getSharedAge).toHaveBeenCalledTimes(2);
+    expect(pretendServer.getClientName).toHaveBeenCalledTimes(1);
+  });
+
   it('creates typed value overrides and runs them when attached', async () => {
     const createForm = defineMultiStepForm({
       steps: {

--- a/packages/react/test/step-schema/overrides.test.tsx
+++ b/packages/react/test/step-schema/overrides.test.tsx
@@ -70,6 +70,54 @@ function createDeferred<T>() {
 }
 
 describe('step overrides', () => {
+  it('creates typed value overrides and runs them when attached', async () => {
+    const createForm = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            profile: {
+              defaultValue: {
+                name: 'Taylor',
+                active: false,
+              },
+              type: 'object.profile',
+            },
+          },
+        },
+      },
+    }).configure();
+    const override = createForm.createValueOverride({
+      step: 'step1',
+      values: ({ fields }) => {
+        expectTypeOf(fields.profile.type).toEqualTypeOf<'object.profile'>();
+        expectTypeOf(fields.profile.defaultValue).toEqualTypeOf<{
+          name: string;
+          active: boolean;
+        }>();
+
+        return {
+          profile: {
+            name: fields.profile.defaultValue.name,
+            active: true,
+          },
+        };
+      },
+    });
+    const schema = createForm().withOverrides({ step1: override });
+
+    await vi.waitFor(() => {
+      expect(
+        schema.stepSchema.value.step1.fields.profile.defaultValue,
+      ).toEqual({ name: 'Taylor', active: true });
+    });
+    expect(
+      Reflect.apply(schema.stepSchema.getStepStatus, schema.stepSchema, [
+        'step1',
+      ]),
+    ).toBe('resolved');
+  });
+
   it('suspends the full step through Suspend', async () => {
     const deferred = createDeferred<{ firstName: string }>();
     const createForm = defineMultiStepForm({


### PR DESCRIPTION
## Summary

- preserve all resolved field metadata across core and React public helpers
- preserve nested object types in React `defaultValues.flat`
- move value override creation and execution into core while exposing it through React
- add configured `defaultOverrides` that run for every instance, with instance overrides taking precedence

## Why

Resolved fields previously dropped metadata outside a small hard-coded set, and React's flat default-value type did not recursively preserve nested object shapes. Override behavior was also split across packages and attached resolvers were not started consistently.

Centralizing override merging and resolution in core gives core and React the same behavior. Default overrides now load shared data for every instance, while an instance-specific override replaces only its targeted resolver without triggering discarded duplicate requests.

## Validation

- full core and React package tests
- package typechecks
- core, React, and example consumer builds
- server-backed override tests covering instance precedence and request counts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cdd4ad8e6fb834dda51eec71d88347e91e58bcf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->