### PR TITLE
fix: restore field metadata and lock withOverrides chaining

### DIFF
--- a/.changeset/lazy-overrides-lock.md
+++ b/.changeset/lazy-overrides-lock.md
@@ -1,0 +1,6 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+'@jfdevelops/react-multi-step-form': patch
+---
+
+Prevent `withOverrides` from being chained a second time on the same instance, removing the race where a superseded instance's override resolver could still run.

--- a/.changeset/quiet-fields-persist.md
+++ b/.changeset/quiet-fields-persist.md
@@ -1,0 +1,5 @@
+---
+'@jfdevelops/multi-step-form-core': patch
+---
+
+Fix storage sync discarding function-valued field metadata (e.g. a date field's `transform`) by restoring it from the in-memory fields instead of the JSON-parsed storage value.

--- a/packages/core/src/define.ts
+++ b/packages/core/src/define.ts
@@ -218,11 +218,23 @@ export interface MultiStepFormInstance<
    *
    * Overrides supplied here are **not** shared across instances created from the same
    * definition — attach different overrides to each instance independently.
+   *
+   * Can only be called once per instance — the returned instance no longer exposes
+   * `withOverrides`, and calling it again at runtime throws.
    */
   withOverrides(
     overrides: WithOverridesMap<def['steps']>,
-  ): MultiStepFormInstance<def, value>;
+  ): MultiStepFormInstanceWithOverridesApplied<def, value>;
 }
+
+/**
+ * The shape of a {@linkcode MultiStepFormInstance} after `withOverrides` has been applied.
+ * `withOverrides` cannot be chained — it may only be called once per instance.
+ */
+export type MultiStepFormInstanceWithOverridesApplied<
+  def extends DefineConfig,
+  value extends instantiateSteps<def> = instantiateSteps<def>,
+> = Omit<MultiStepFormInstance<def, value>, 'withOverrides'>;
 
 class MultiStepFormInstanceImpl<const def extends DefineConfig>
   extends MultiStepFormSchema<def>
@@ -232,6 +244,7 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
   readonly #rawSteps: def['steps'];
   readonly #storageConfig: BaseStorageConfig<string>;
   readonly #onRebuild: (next: MultiStepFormInstanceImpl<def>) => void;
+  #overridesApplied: boolean;
 
   constructor(options: {
     steps: def['steps'];
@@ -239,6 +252,7 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
     storageConfig: BaseStorageConfig<string>;
     instanceName: string;
     onRebuild: (next: MultiStepFormInstanceImpl<def>) => void;
+    overridesApplied?: boolean;
   }) {
     const {
       steps,
@@ -246,6 +260,7 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
       storageConfig,
       instanceName,
       onRebuild,
+      overridesApplied = false,
     } = options;
 
     super({
@@ -258,9 +273,18 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
     this.#rawSteps = steps;
     this.#storageConfig = storageConfig;
     this.#onRebuild = onRebuild;
+    this.#overridesApplied = overridesApplied;
   }
 
   withOverrides(overrides: WithOverridesMap<def['steps']>) {
+    InvalidInstanceError.invariant(!this.#overridesApplied, {
+      reason:
+        '"withOverrides" was already applied to this instance and cannot be chained again. Call "withOverrides" once, on the instance returned by the factory.',
+      instance: this.instanceName,
+    });
+
+    this.#overridesApplied = true;
+
     const mergedSteps = mergeStepOverrides(this.#rawSteps, overrides);
 
     const next = new MultiStepFormInstanceImpl<def>({
@@ -269,13 +293,14 @@ class MultiStepFormInstanceImpl<const def extends DefineConfig>
       storageConfig: this.#storageConfig,
       instanceName: this.instanceName,
       onRebuild: this.#onRebuild,
+      overridesApplied: true,
     });
 
     this.#onRebuild(next);
 
     next.stepSchema.resolveOverrides();
 
-    return next as unknown as MultiStepFormInstance<def>;
+    return next as unknown as MultiStepFormInstanceWithOverridesApplied<def>;
   }
 }
 

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -669,6 +669,62 @@ export class MultiStepFormStepSchema<
   }
 
   /**
+   * Persisted storage is JSON, so function-valued field metadata (e.g. a date field's
+   * `transform`) never survives the round trip. Restore it from the current, in-memory
+   * fields — only `defaultValue` is trusted from storage.
+   */
+  private restoreFieldMetadata(storageValues: value): value {
+    const merged: Record<string, unknown> = { ...storageValues };
+    const currentValue = this.value as unknown as Record<string, unknown>;
+
+    for (const [stepKey, storedStep] of Object.entries(merged)) {
+      const currentStep = currentValue[stepKey] as
+        | { fields?: Record<string, Record<string, unknown>> }
+        | undefined;
+
+      if (
+        !currentStep?.fields ||
+        typeof storedStep !== 'object' ||
+        storedStep === null ||
+        !('fields' in storedStep) ||
+        typeof (storedStep as { fields?: unknown }).fields !== 'object'
+      ) {
+        continue;
+      }
+
+      const currentFields = currentStep.fields;
+      const storedFields = (
+        storedStep as { fields: Record<string, Record<string, unknown>> }
+      ).fields;
+      const nextFields: Record<string, unknown> = { ...currentFields };
+
+      for (const [fieldName, storedField] of Object.entries(storedFields)) {
+        const currentField = currentFields[fieldName];
+
+        if (
+          !currentField ||
+          typeof storedField !== 'object' ||
+          storedField === null
+        ) {
+          continue;
+        }
+
+        nextFields[fieldName] = {
+          ...currentField,
+          defaultValue: storedField.defaultValue,
+        };
+      }
+
+      merged[stepKey] = {
+        ...storedStep,
+        fields: nextFields,
+      };
+    }
+
+    return merged as value;
+  }
+
+  /**
    * Syncs the values from storage to {@linkcode value}.
    */
   sync() {
@@ -676,7 +732,8 @@ export class MultiStepFormStepSchema<
     const storageValues = this.__getStorage().get();
 
     if (storageValues) {
-      const enrichedValues = this.#internal.enrichValues(storageValues);
+      const restoredValues = this.restoreFieldMetadata(storageValues);
+      const enrichedValues = this.#internal.enrichValues(restoredValues);
 
       this.value = { ...enrichedValues };
     }

--- a/packages/core/src/steps/schema.ts
+++ b/packages/core/src/steps/schema.ts
@@ -687,7 +687,9 @@ export class MultiStepFormStepSchema<
         typeof storedStep !== 'object' ||
         storedStep === null ||
         !('fields' in storedStep) ||
-        typeof (storedStep as { fields?: unknown }).fields !== 'object'
+        storedStep.fields === null ||
+        typeof storedStep.fields !== 'object'
+
       ) {
         continue;
       }

--- a/packages/core/test/define.test.ts
+++ b/packages/core/test/define.test.ts
@@ -430,6 +430,20 @@ describe('defineMultiStepForm: withOverrides', () => {
       'AdminDefault',
     );
   });
+
+  it('throws when withOverrides is chained a second time on the same instance', () => {
+    const createForm = createBookingDefinition().configure();
+    const instance = createForm({ instance: 'client' }).withOverrides({
+      step1: async () => ({ firstName: 'ClientDefault' }),
+    });
+
+    expect(() => {
+      // @ts-expect-error withOverrides is not chainable once applied
+      instance.withOverrides({
+        step1: async () => ({ firstName: 'AnotherDefault' }),
+      });
+    }).toThrow(InvalidInstanceError);
+  });
 });
 
 describe('defineMultiStepForm: shared createHelperFn', () => {

--- a/packages/core/test/field-metadata-and-is-complete.test.ts
+++ b/packages/core/test/field-metadata-and-is-complete.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { defineMultiStepForm } from '../src';
+import { createMockStorage } from './utils/create-mock-storage';
 
 describe('field metadata: placeholder, isRequired, errorMessage', () => {
   it('resolves isRequired to false by default', () => {
@@ -131,6 +132,95 @@ describe('field metadata: placeholder, isRequired, errorMessage', () => {
       errorMessage: 'Enter a valid email',
       type: 'string.email',
     });
+  });
+
+  it('keeps every field metadata property intact after a storage-backed update round trip', () => {
+    const mockStorage = createMockStorage();
+    const transform = vi.fn((value: Date) => value.toISOString().slice(0, 10));
+
+    const createForm = defineMultiStepForm({
+      steps: {
+        step1: {
+          title: 'Step 1',
+          fields: {
+            firstName: {
+              defaultValue: '',
+              placeholder: 'Jane',
+              label: 'Given name',
+              isRequired: true,
+              errorMessage: 'First name is required',
+              type: 'string.custom',
+              nameTransformCasing: 'camel',
+            },
+            birthDate: {
+              defaultValue: new Date('2024-01-01'),
+              type: 'string',
+              transform,
+            },
+          },
+        },
+      },
+    }).configure({
+      storage: {
+        key: `field-metadata-storage-test-${Date.now()}`,
+        store: mockStorage,
+      },
+    });
+    const instance = createForm();
+    const expectedMetadata = {
+      firstName: {
+        name: 'firstName',
+        placeholder: 'Jane',
+        label: 'Given name',
+        isRequired: true,
+        errorMessage: 'First name is required',
+        type: 'string.custom',
+        nameTransformCasing: 'camel',
+      },
+      birthDate: {
+        name: 'birthDate',
+        transform,
+        type: 'string',
+      },
+    };
+
+    // Sanity check: the metadata is present before anything touches storage.
+    expect(instance.stepSchema.value.step1.fields.firstName).toMatchObject(
+      expectedMetadata.firstName,
+    );
+    expect(instance.stepSchema.value.step1.fields.birthDate).toMatchObject(
+      expectedMetadata.birthDate,
+    );
+
+    // An update persists the step to storage and immediately syncs back from it —
+    // the exact path that used to drop metadata lost in the JSON round trip.
+    instance.stepSchema.update({
+      targetStep: 'step1',
+      fields: ['fields.firstName.defaultValue'],
+      updater: 'Taylor',
+    });
+
+    const firstName = instance.stepSchema.value.step1.fields.firstName;
+    const birthDate = instance.stepSchema.value.step1.fields.birthDate;
+
+    expect(firstName).toMatchObject(expectedMetadata.firstName);
+    expect(firstName.defaultValue).toBe('Taylor');
+    expect(birthDate).toMatchObject(expectedMetadata.birthDate);
+    expect(typeof birthDate.transform).toBe('function');
+    expect(birthDate.transform).toBe(transform);
+
+    // A fresh sync from storage (e.g. what "mount" triggers) must also preserve it.
+    instance.stepSchema.sync();
+
+    expect(
+      instance.stepSchema.value.step1.fields.firstName,
+    ).toMatchObject(expectedMetadata.firstName);
+    expect(instance.stepSchema.value.step1.fields.birthDate).toMatchObject(
+      expectedMetadata.birthDate,
+    );
+    expect(instance.stepSchema.value.step1.fields.birthDate.transform).toBe(
+      transform,
+    );
   });
 });
 

--- a/packages/core/test/step-schema/update.test.ts
+++ b/packages/core/test/step-schema/update.test.ts
@@ -371,6 +371,48 @@ describe('multi step form step schema: update', () => {
     );
   });
 
+  it('preserves function-valued field metadata (e.g. a date field\'s transform) across a storage-backed update', () => {
+    const mockStorage = createMockStorage();
+    const transform = vi.fn((value: Date) => value.toISOString().slice(0, 10));
+
+    const schema = defineMultiStepForm({
+      steps: {
+        step1: {
+          fields: {
+            birthDate: {
+              defaultValue: new Date('2024-01-01'),
+              type: 'string',
+              transform,
+            },
+          },
+          title: 'Step 1',
+        },
+      },
+    }).configure({
+      storage: {
+        key: `transform-storage-test-${Date.now()}`,
+        store: mockStorage,
+      },
+    })();
+
+    expect(schema.stepSchema.value.step1.fields.birthDate.transform).toBe(
+      transform
+    );
+
+    schema.stepSchema.update({
+      targetStep: 'step1',
+      fields: ['fields.birthDate.defaultValue'],
+      updater: JSON.stringify(new Date('2024-12-31')) as never,
+    });
+
+    expect(schema.stepSchema.value.step1.fields.birthDate.transform).toBe(
+      transform
+    );
+    expect(
+      typeof schema.stepSchema.value.step1.fields.birthDate.transform
+    ).toBe('function');
+  });
+
   describe('mode config (shallow)', () => {
     it('should another key', () => {
       const schema = defineMultiStepForm({

--- a/packages/react/src/define.ts
+++ b/packages/react/src/define.ts
@@ -82,8 +82,17 @@ export interface MultiStepFormReactInstance<
    */
   withOverrides(
     overrides: WithOverridesMap<def['steps']>,
-  ): MultiStepFormReactInstance<def, value>;
+  ): MultiStepFormReactInstanceWithOverridesApplied<def, value>;
 }
+
+/**
+ * The shape of a {@linkcode MultiStepFormReactInstance} after `withOverrides` has been applied.
+ * `withOverrides` cannot be chained — it may only be called once per instance.
+ */
+export type MultiStepFormReactInstanceWithOverridesApplied<
+  def extends DefineConfig,
+  value extends instantiateReactSteps<def> = instantiateReactSteps<def>,
+> = Omit<MultiStepFormReactInstance<def, value>, 'withOverrides'>;
 
 function createNoopStorage(): Storage {
   return {
@@ -111,6 +120,7 @@ function attachInstance<
     storageConfig: BaseStorageConfig<string>;
     instanceName: TInstance;
     onRebuild: (next: MultiStepFormReactInstance<def>) => void;
+    overridesApplied?: boolean;
   },
 ): MultiStepFormReactInstance<def> {
   const {
@@ -119,11 +129,21 @@ function attachInstance<
     storageConfig,
     instanceName,
     onRebuild,
+    overridesApplied: initialOverridesApplied = false,
   } = options;
+  let overridesApplied = initialOverridesApplied;
 
   return Object.assign(instance, {
     instanceName,
     withOverrides(overrides: WithOverridesMap<def['steps']>) {
+      InvalidInstanceError.invariant(!overridesApplied, {
+        reason:
+          '"withOverrides" was already applied to this instance and cannot be chained again. Call "withOverrides" once, on the instance returned by the factory.',
+        instance: instanceName,
+      });
+
+      overridesApplied = true;
+
       const mergedSteps = mergeStepOverrides(rawSteps, overrides);
 
       const next = attachInstance<def, TInstance>(
@@ -138,6 +158,7 @@ function attachInstance<
           storageConfig,
           instanceName,
           onRebuild,
+          overridesApplied: true,
         },
       );
 

--- a/packages/react/test/define.test.ts
+++ b/packages/react/test/define.test.ts
@@ -258,6 +258,20 @@ describe('react defineMultiStepForm: withOverrides', () => {
       'ClientDefault',
     );
   });
+
+  it('throws when withOverrides is chained a second time on the same instance', () => {
+    const createForm = createBookingDefinition().configure();
+    const instance = createForm({ instance: 'client' }).withOverrides({
+      step1: async () => ({ firstName: 'ClientDefault' }),
+    });
+
+    expect(() => {
+      // @ts-expect-error withOverrides is not chainable once applied
+      instance.withOverrides({
+        step1: async () => ({ firstName: 'AnotherDefault' }),
+      });
+    }).toThrow(InvalidInstanceError);
+  });
 });
 
 describe('react defineMultiStepForm: shared createHelperFn', () => {


### PR DESCRIPTION
## Summary
- Restore function-valued field metadata (e.g. a date field's `transform`) after storage sync, instead of letting the JSON round trip discard it
- Prevent `withOverrides` from being chained a second time on an instance, closing the race where a superseded instance's override resolver could still run

## Test plan
- [x] `pnpm --filter=@jfdevelops/multi-step-form-core test`
- [x] `pnpm --filter=@jfdevelops/react-multi-step-form test`
- [x] `pnpm run typecheck:packages`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 638a38f16f90063dc9507a2b1fd4a81756472925. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->